### PR TITLE
Use re-usable GH actions to run CI

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -10,62 +10,25 @@ jobs:
   linting:
     runs-on: ubuntu-latest
     steps:
-      - name: checkout source
-        uses: actions/checkout@v2
-      - name: set up python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-      - name: set PY
-        run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
-      - name: cache stuff
-        uses: actions/cache@v2
-        with:
-          path: |
-            ${{ env.pythonLocation }}
-            ~/.cache/pre-commit
-          key: |
-            pre-commit-${{ env.PY }}-${{ hashFiles('.pre-commit-config.yaml') }}
-      - name: install dependencies
-        run: pip install pre-commit
-      - name: Install pre-commit hooks
-        run: pre-commit install
-      # This will run on all files in the repo not just those that have been
-      # committed. Once formatting has been applied once globally, from then on
-      # the files being changed by pre-commit should be just those that are
-      # being committed - provided that people are using the pre-commit hook to
-      # format their code.
-      - name: run pre-commit
-        run: pre-commit run --all-files --color always
+      - uses: brainglobe/actions/lint@v1
 
   test:
     needs: linting
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9]
-        exclude:
-          - {os: "windows-latest", python-version: "3.7"}
-          - {os: "windows-latest", python-version: "3.8"}
+        # Run all supported Python versions on linux
+        python-version: ["3.7", "3.8", "3.9"]
+        os: [ubuntu-latest]
+        include:
+          # Include one windows run
+          - os: windows-latest
+            python-version: "3.9"
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v2
+      - uses: brainglobe/actions/test@v1
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e .[dev]
-      - name: Test
-        run: pytest
-      - name: Coveralls
-        env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-            pip install coveralls
-            coveralls --service=github
+
 
   deploy:
     needs: test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       hooks:
           - id: flake8
     - repo: https://github.com/psf/black
-      rev: 22.1.0
+      rev: 22.3.0
       hooks:
           - id: black
     - repo: https://github.com/pre-commit/mirrors-mypy

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,12 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{37,38}-{linux,windows}
+envlist = py{37,38,39}-{linux,windows}
 
 [gh-actions]
 python =
     3.7: py37
     3.8: py38
-
-[gh-actions:env]
-PLATFORM =
-    ubuntu-latest: linux
-    windows-latest: windows
+    3.9: py39
 
 [testenv]
 commands = pytest -v --cov=./ --cov-report=xml


### PR DESCRIPTION
Also fixes https://github.com/brainglobe/cellfinder/issues/194 by using the tox file