### PR TITLE
Debug running coredev tests

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -1,19 +1,23 @@
 name: tests
 
+inputs:
+  coredev:
+    description: 'Tests with development version of cellfinder-core?'
+    required: true
+    default: 'false'
+
 on:
   push:
   pull_request:
   # Enable manual runs
   workflow_dispatch:
-    inputs:
-      coredev:
-        description: 'Tests with development version of cellfinder-core?'
-        required: true
-        default: 'false'
+
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  INPUT_COREDEV: 'true'
+
 
 jobs:
   linting:
@@ -24,6 +28,8 @@ jobs:
   test:
     needs: linting
     runs-on: ${{ matrix.os }}
+    env:
+      INPUT_COREDEV: ${{ github.event.inputs.coredev }}
     strategy:
       matrix:
         # Run all supported Python versions on linux


### PR DESCRIPTION
https://github.com/brainglobe/cellfinder/pull/199 didn't work, but needed to be merged to test it. This PR is to debug and fix running manual tests with the development version of `cellfinder-core`.