### PR TITLE
Don't specify QT backend in requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ requirements = [
     "psutil",
     "configobj",
     "tensorflow>=2.5.0",
-    "napari[pyside2]>=0.3.7",
+    "napari>=0.3.7",
     "brainglobe-napari-io",
     "cellfinder-napari",
     "slurmio>=0.0.4",


### PR DESCRIPTION
See https://napari.org/plugins/best_practices.html#don-t-include-pyside2-or-pyqt5-in-your-plugin-s-dependencies as to why this is not a good thing to do.