### PR TITLE
Revert "Don't specify QT backend in requirements"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ requirements = [
     "psutil",
     "configobj",
     "tensorflow>=2.5.0",
-    "napari>=0.3.7",
+    "napari[pyside2]>=0.3.7",
     "brainglobe-napari-io",
     "cellfinder-napari",
     "slurmio>=0.0.4",


### PR DESCRIPTION
Reverts brainglobe/cellfinder#205 As discussed with Adam on Slack.