### PR TITLE
Remove multiprocessing-logging from requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ requirements = [
     "tifffile",
     "natsort",
     "tqdm",
-    "multiprocessing-logging",
     "psutil",
     "configobj",
     "tensorflow>=2.5.0",


### PR DESCRIPTION
The errors in https://github.com/brainglobe/cellfinder/issues/207 are being emitted by `multiprocessing_logging`. Since this package doesn't seem to be used anywhere in `cellfinder` itself, I've removed it here to see if it fixes the tests. I suspect it is being automatically invoked as a pytest plugin, and not interacting well with the multiprocessing being done in `cellfinder-core`.

@adamltyson is there a reason to keep `multiprocessing_logging` as a requirement?