### PR TITLE
Use standard pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,4 @@
 repos:
-    - repo: https://github.com/pycqa/isort
-      rev: 5.12.0
-      hooks:
-          - id: isort
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v4.4.0
       hooks:
@@ -15,15 +11,12 @@ repos:
             args: [--fix=lf]
           - id: requirements-txt-fixer
           - id: trailing-whitespace
-            # bump2version produces whitespace in setup.cfg, so exclude to
-            # not inferfere with versioning
-            exclude: setup.cfg
-    - repo: https://github.com/pycqa/flake8
-      rev: 6.0.0
+    - repo: https://github.com/charliermarsh/ruff-pre-commit
+      rev: v0.0.240
       hooks:
-          - id: flake8
+        - id: ruff
     - repo: https://github.com/psf/black
-      rev: 22.12.0
+      rev: 23.1.0
       hooks:
           - id: black
     - repo: https://github.com/pre-commit/mirrors-mypy
@@ -32,3 +25,4 @@ repos:
           - id: mypy
             additional_dependencies:
                 - types-setuptools
+                - types-requests

--- a/cellfinder/analyse/analyse.py
+++ b/cellfinder/analyse/analyse.py
@@ -93,7 +93,7 @@ def summarise_points(
                 )
             )
             structures_with_points.add(structure)
-        except:
+        except Exception:
             continue
 
     logging.debug("Ensuring output directory exists")

--- a/cellfinder/analyse/analyse.py
+++ b/cellfinder/analyse/analyse.py
@@ -328,7 +328,6 @@ def run_analysis(
     all_points_csv_path,
     summary_csv_path,
 ):
-
     source_shape = tuple(
         imio.get_size_image_from_file_paths(signal_planes).values()
     )

--- a/cellfinder/extract/extract_cubes.py
+++ b/cellfinder/extract/extract_cubes.py
@@ -383,7 +383,6 @@ def main(
     n_free_cpus=4,
     save_empty_cubes=False,
 ):
-
     start_time = datetime.now()
 
     if voxel_sizes[0] != network_voxel_sizes[0]:

--- a/cellfinder/figures/heatmap.py
+++ b/cellfinder/figures/heatmap.py
@@ -34,7 +34,6 @@ def run(
     smoothing=None,
     mask=True,
 ):
-
     points = pd.read_hdf(downsampled_points).values
 
     bins = get_bins(downsampled_shape, (1, 1, 1))

--- a/cellfinder/main.py
+++ b/cellfinder/main.py
@@ -100,7 +100,6 @@ def main():
 
 
 def run_all(args, what_to_run, atlas):
-
     from cellfinder_core.classify import classify
     from cellfinder_core.detect import detect
     from cellfinder_core.tools import prep

--- a/cellfinder/tools/parser.py
+++ b/cellfinder/tools/parser.py
@@ -12,9 +12,8 @@ from argparse import (
     ArgumentTypeError,
 )
 
-from brainreg.cli import atlas_parse
+from brainreg.cli import atlas_parse, geometry_parser, niftyreg_parse
 from brainreg.cli import backend_parse as brainreg_backend_parse
-from brainreg.cli import geometry_parser, niftyreg_parse
 from cellfinder_core.download.cli import (
     download_directory_parser,
     model_parser,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,25 +1,10 @@
 [tool.black]
-target-version = ['py36', 'py37', 'py38']
+target-version = ['py38', 'py39', 'py310']
 skip-string-normalization = false
 line-length = 79
-exclude = '''
-(
-  /(
-      \.eggs
-    | \.git
-    | \.hg
-    | \.mypy_cache
-    | \.tox
-    | \.venv
-    | _build
-    | buck-out
-    | build
-    | dist
-    | examples
-  )/
-)
-'''
 
-[tool.isort]
-profile = "black"
-line_length = 79
+[tool.ruff]
+line-length = 79
+exclude = ["__init__.py","build",".eggs"]
+select = ["I", "E", "F"]
+fix = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,14 +4,14 @@ commit = True
 tag = True
 tag_name = {new_version}
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<rc>\d+))?
-serialize = 
+serialize =
 	{major}.{minor}.{patch}-{release}{rc}
 	{major}.{minor}.{patch}
 
 [bumpversion:part:release]
 optional_value = prod
 first_value = rc
-values = 
+values =
 	rc
 	prod
 

--- a/tests/tests/test_integration/test_extract.py
+++ b/tests/tests/test_integration/test_extract.py
@@ -155,7 +155,6 @@ def test_cube_extraction(tmpdir, depth=20):
     args.voxel_sizes[0] = 0.1
 
     with pytest.raises(extract_cubes.StackSizeError):
-
         extract_cubes.main(
             get_cells(args.paths.cells_file_path),
             args.paths.tmp__cubes_output_dir,


### PR DESCRIPTION
This applies the standard pre-commit-config.yaml file from https://github.com/SainsburyWellcomeCentre/python-cookiecutter, and fixes files as needed for this new config.