### PR TITLE
Force version of brainglobe-utils that has the `DefaultDict` fix.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ requirements = [
     "configobj",
     "fancylog>=0.0.7",
     "imio",
-    "brainglobe-utils",
+    "brainglobe-utils>=0.2.5",
     "multiprocessing-logging>=0.3.4",
     "natsort",
     "numpy",


### PR DESCRIPTION
## Description

Force version of brainglobe-utils that has the `DefaultDict` fix.

This will let us trigger a new release that means the `cellfinder-core` tests should pass.

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

**What does this PR do?**

## References

## How has this PR been tested?

## Is this a breaking change?

## Does this PR require an update to the documentation?

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
