### PR TITLE
Update manual version

### DIFF
--- a/cellfinder/__init__.py
+++ b/cellfinder/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.4.21"
+__version__ = "0.7.0"
 __author__ = "Adam Tyson, Christian Niedworok, Charly Rousseau"
 __license__ = "BSD-3-Clause"

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ requirements = [
 
 setup(
     name="cellfinder",
-    version="0.4.21",
+    version="0.7.0",
     description="Automated 3D cell detection and registration of "
     "whole-brain images",
     long_description=long_description,


### PR DESCRIPTION
Apologies for the PR noise.

New version in setup.py for patched version, so we can release `v0.7.0` to PyPI.

There look to be old tags (v0.6.0) that are datestamped 2020, but the latest releases are from 2021 and only reach v0.4.21.

Bumping to version `v0.7.0` to skip around this ambiguity. Will generate release notes once pushed to PyPI.

Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).
