### PR TITLE
Update to brainreg v1 compliance

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -46,7 +46,7 @@ jobs:
         - os: windows-latest
           python-version: "3.9"
         - os: ubuntu-latest
-          python-version: "3.11"
+          python-version: "3.10"
     steps:
       - uses: neuroinformatics-unit/actions/test@v2
         with:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -46,7 +46,7 @@ jobs:
         - os: windows-latest
           python-version: "3.9"
         - os: ubuntu-latest
-          python-version: "3.8"
+          python-version: "3.11"
     steps:
       - uses: neuroinformatics-unit/actions/test@v2
         with:

--- a/cellfinder/main.py
+++ b/cellfinder/main.py
@@ -42,7 +42,7 @@ def cells_exist(points_file):
 
 def main():
     suppress_tf_logging(tf_suppress_log_messages)
-    from brainreg.main import main as register
+    from brainreg.core.main import main as register
 
     from cellfinder.tools import prep
 

--- a/cellfinder/tools/parser.py
+++ b/cellfinder/tools/parser.py
@@ -16,8 +16,8 @@ from brainglobe_utils.general.numerical import (
     check_positive_float,
     check_positive_int,
 )
-from brainreg.cli import atlas_parse, geometry_parser, niftyreg_parse
-from brainreg.cli import backend_parse as brainreg_backend_parse
+from brainreg.core.cli import atlas_parse, geometry_parser, niftyreg_parse
+from brainreg.core.cli import backend_parse as brainreg_backend_parse
 from cellfinder_core.download.cli import (
     download_directory_parser,
     model_parser,

--- a/cellfinder/tools/prep.py
+++ b/cellfinder/tools/prep.py
@@ -14,7 +14,7 @@ from pathlib import PurePath
 from bg_atlasapi import BrainGlobeAtlas
 from brainglobe_utils.general.exceptions import CommandLineInputError
 from brainglobe_utils.general.system import ensure_directory_exists
-from brainreg.paths import Paths as BrainRegPaths
+from brainreg.core.paths import Paths as BrainRegPaths
 from fancylog import fancylog
 
 import cellfinder as program_for_log

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "cellfinder"
 description = "Automated 3D cell detection and registration of whole-brain images"
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 authors = [
     { name = "Adam Tyson", email = "code@adamltyson.com" },
     { name = "Christian Niedworok" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Intended Audience :: Science/Research",
 ]
 dependencies = [
-    "brainreg",
+    "brainreg>=1.0.0",
     "cellfinder-core>=0.2.4",
     "configobj",
     "fancylog>=0.0.7",

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{38,39,310}-{coredev}
+envlist = py{39,310,311}-{coredev}
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
 
 [gh-actions:env]
 # This runs the coredev environment if the "coredev" github actions input

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{39,310,311}-{coredev}
+envlist = py{39,310}-{coredev}
 
 [gh-actions]
 python =
     3.9: py39
     3.10: py310
-    3.11: py311
 
 [gh-actions:env]
 # This runs the coredev environment if the "coredev" github actions input


### PR DESCRIPTION
Updates cellfinder to be compliant with the upcoming release of `brainreg` version 1, as per https://github.com/brainglobe/brainreg/pull/146.

Note that `pyproject.toml` now pins the `brainreg` version to be `v1.0.0` to prevent users from installing an old version of `brainreg` through their `cellfinder` install.

## Merge order

This needs to be merged after https://github.com/brainglobe/brainreg/pull/146 _and_ the new release of `brainreg` (version 1.0.0) is available on PyPI.

CI will fail until these conditions are met.

## On merge

`cellfinder` will need a new release. This release version _must_ be <`v1.0.0`.