### PR TITLE
Fix pathing problems

### DIFF
--- a/tests/tests/test_unit/test_analyse.py
+++ b/tests/tests/test_unit/test_analyse.py
@@ -1,5 +1,5 @@
 import filecmp
-from importlib.resources import files
+import os
 from pathlib import Path
 
 import pytest
@@ -37,15 +37,18 @@ def structures_with_points():
 def test_get_region_totals(tmp_path, points, structures_with_points):
     """Regression test for get_region_totals for pandas 1.5.3 -> 2.1.3+.
     pd.Dataframe.append was deprecated and remove in this time."""
-    volumes_path = files("cellfinder").joinpath(
-        "../tests/data/analyse/volumes.csv"
+    OUTPUT_DATA_LOC = (
+        Path(os.path.dirname(os.path.abspath(__file__))) / "../../data/analyse"
+    ).resolve()
+
+    volumes_path = OUTPUT_DATA_LOC / "volumes.csv"
+    expected_output = (
+        OUTPUT_DATA_LOC / "region_totals_regression_pandas1_5_3.csv"
     )
+
     output_path = Path(tmp_path / "tmp_region_totals.csv")
     get_region_totals(
         points, structures_with_points, volumes_path, output_path
     )
     assert output_path.exists()
-    expected_output = files("cellfinder").joinpath(
-        "../tests/data/analyse/region_totals_regression_pandas1_5_3.csv"
-    )
     assert filecmp.cmp(output_path, expected_output)

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ INPUT_COREDEV =
     true: coredev
 
 [testenv]
-commands = pytest -v --cov=./ --cov-report=xml
+commands = pytest {toxinidir} -v --cov=./ --cov-report=xml
 deps =
     pytest-cov
     pytest


### PR DESCRIPTION
@alessandrofelder Noticed your test data wasn't being found because our `MANIFEST` is told to ignore the `tests` directory when packaging.

Changed the `tox` command and paths in the to-be regression tests to point to the repository clone, which should then resolve the paths correctly using the repo clone.