### PR TITLE
Prepare for migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+# Cellfinder has moved!
+
+As part of [our BrainGlobe version 1 update](https://brainglobe.info/blog/version1/version_1_announcement.html), the `cellfinder` workflow that can be run from the command line [has moved into `brainglobe-workflows`](https://github.com/brainglobe/brainglobe-workflows).
+Please head over to that package to install an up-to-date version of `cellfinder`.
+
+You can keep up to date with the version 1 rollout by [visiting our blog page](https://brainglobe.info/blog/index.html), or joining us [over on Zulip](https://brainglobe.zulipchat.com).
+
+---
+
 [![Python Version](https://img.shields.io/pypi/pyversions/cellfinder.svg)](https://pypi.org/project/cellfinder)
 [![PyPI](https://img.shields.io/pypi/v/cellfinder.svg)](https://pypi.org/project/cellfinder)
 [![Downloads](https://pepy.tech/badge/cellfinder)](https://pepy.tech/project/cellfinder)

--- a/cellfinder/__init__.py
+++ b/cellfinder/__init__.py
@@ -1,7 +1,7 @@
 import warnings
 
 warnings.warn(
-    "cellfinder (CLI) has migrated. Please use brainglobe-workflows instead: https://github.com/brainglobe/brainglobe-workflows",
+    "cellfinder (the command line tool) has migrated. Please use brainglobe-workflows instead: https://github.com/brainglobe/brainglobe-workflows",
     DeprecationWarning,
 )
 

--- a/cellfinder/__init__.py
+++ b/cellfinder/__init__.py
@@ -1,3 +1,10 @@
+import warnings
+
+warnings.warn(
+    "cellfinder (CLI) has migrated. Please use brainglobe-workflows instead: https://github.com/brainglobe/brainglobe-workflows",
+    DeprecationWarning,
+)
+
 from importlib.metadata import metadata
 
 __version__ = metadata("cellfinder")["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,11 +23,11 @@ classifiers = [
 ]
 dependencies = [
     "brainreg>=1.0.0",
-    "cellfinder-core>=0.2.4",
+    "cellfinder-core>=0.2.4,<1.0.0",
     "configobj",
     "fancylog>=0.0.7",
     "imio",
-    "brainglobe-utils>=0.2.5",
+    "brainglobe-utils>=0.2.5,<1.0.0",
     "multiprocessing-logging>=0.3.4",
     "natsort",
     "numpy",
@@ -52,7 +52,11 @@ dev = [
     "pre-commit",
     "setuptools_scm",
 ]
-napari = ["napari[pyside2]", "brainglobe-napari-io", "cellfinder-napari"]
+napari = [
+    "napari[pyside2]",
+    "brainglobe-napari-io<1.0.0",
+    "cellfinder-napari<1.0.0",
+]
 
 [project.urls]
 source = "https://github.com/brainglobe/cellfinder"

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ INPUT_COREDEV =
     true: coredev
 
 [testenv]
-commands = pytest {toxinidir} -v --cov=./ --cov-report=xml
+commands = pytest {toxinidir} -v --cov=./ --cov-report=xml -W ignore::DeprecationWarning
 deps =
     pytest-cov
     pytest


### PR DESCRIPTION
See https://github.com/brainglobe/BrainGlobe/issues/45

Prepares the CLI-cellfinder package for migration into brainglobe-workflows.

Note that we do not want to archive the repository, since we need it for when we merge in cellfinder-core and cellfinder-napari.

On merge, tag new release version so that the deprecation warning files through to PyPI.