### PR TITLE
Reinstate brainmapper ci check

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -92,43 +92,42 @@ jobs:
 
   # Run brainglobe-workflows brainmapper-CLI tests to check for
   # breakages
-  # test_brainmapper_cli:
-  #   needs: [linting, manifest]
-  #   name: Run brainmapper tests to check for breakages
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Cache tensorflow model
-  #       uses: actions/cache@v3
-  #       with:
-  #         path: "~/.cellfinder"
-  #         key: models-${{ hashFiles('~/.cellfinder/**') }}
+  test_brainmapper_cli:
+    needs: [linting, manifest]
+    name: Run brainmapper tests to check for breakages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache tensorflow model
+        uses: actions/cache@v3
+        with:
+          path: "~/.cellfinder"
+          key: models-${{ hashFiles('~/.cellfinder/**') }}
 
-  #     - name: Checkout brainglobe-workflows
-  #       uses: actions/checkout@v3
-  #       with:
-  #         repository: 'brainglobe/brainglobe-workflows'
+      - name: Checkout brainglobe-workflows
+        uses: actions/checkout@v3
+        with:
+          repository: 'brainglobe/brainglobe-workflows'
 
-  #     - name: Set up Python 3.10
-  #       uses: actions/setup-python@v3
-  #       with:
-  #         python-version: "3.10"
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
 
-  #     - name: Install test dependencies
-  #       run: |
-  #         python -m pip install --upgrade pip wheel
-  #         # Install latest SHA on this brainglobe-workflows branch
-  #         python -m pip install git+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA
-  #         # Install checked out copy of brainglobe-workflows
-  #         python -m pip install .[dev]
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip wheel
+          # Install latest SHA on this brainglobe-workflows branch
+          python -m pip install git+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA
+          # Install checked out copy of brainglobe-workflows
+          python -m pip install .[dev]
 
-  #     - name: Run brainmapper tests in brainglobe-workflows
-  #       run: |
-  #         python -m pytest --color=yes -v tests/brainmapper
+      - name: Run brainmapper tests in brainglobe-workflows
+        run: |
+          python -m pytest --color=yes -v tests/brainmapper
 
   build_sdist_wheel:
     name: Build source distribution and wheel
     # needs: [test, test_brainmapper_cli, test_numba_disabled]
-    needs: [test]
     if: github.event_name == 'push' && github.ref_type == 'tag'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -127,7 +127,7 @@ jobs:
 
   build_sdist_wheel:
     name: Build source distribution and wheel
-    # needs: [test, test_brainmapper_cli, test_numba_disabled]
+    needs: [test, test_brainmapper_cli, test_numba_disabled]
     if: github.event_name == 'push' && github.ref_type == 'tag'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -40,7 +40,7 @@ jobs:
       matrix:
         # Run all supported Python versions on linux
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10"]
         # Include one windows, one macos run
         include:
         - os: macos-latest

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ However, we recommend that users install `cellfinder` either through installing 
 
 ```bash
 # If you want to install all BrainGlobe tools, including cellfinder, in a consistent manner with one command:
-pip install brainglobe>=1.0.0 
+pip install brainglobe>=1.0.0
 # If you want to install the brainmapper CLI tool as well:
 pip install brainglobe-workflows>=1.0.0
 ```

--- a/README.md
+++ b/README.md
@@ -26,13 +26,23 @@ At a glance:
 ## Installation
 
 You can find [the installation instructions](https://brainglobe.info/documentation/cellfinder/installation.html#installation) on the BrainGlobe website, which will go into more detail about the installation process if you want to minimise your installation to suit your needs.
-However, we recommend that users install `cellfinder` either through installing BrainGlobe version 1, or (if you also want the command-line interface) installing `brainglobe-workflows`:
+However, we recommend that users install `cellfinder` either through installing BrainGlobe version 1, or (if you also want the command-line interface) installing `brainglobe-workflows`.
 
 ```bash
-pip install cellfinder>=1.0.0 # If you just want the napari plugin and Python API
-pip install brainglobe>=1.0.0 # If you want to install all BrainGlobe tools, including cellfinder, in a consistent manner with one command
-pip install brainglobe-workflows>=1.0.0 # If you want to include the CLI
+# If you want to install all BrainGlobe tools, including cellfinder, in a consistent manner with one command:
+pip install brainglobe>=1.0.0 
+# If you want to install the brainmapper CLI tool as well:
+pip install brainglobe-workflows>=1.0.0
 ```
+
+If you only want the `cellfinder` package by itself, you can `pip install` it alone:
+
+```bash
+pip install cellfinder>=1.0.0
+```
+
+Be sure to specify a version greater than version `v1.0.0` - prior to this version the `cellfinder` package had a very different structure that is incompatible with BrainGlobe version 1 and the other tools in the BrainGlobe suite.
+See [our blog posts](https://brainglobe.info/blog/) for more information on the release of BrainGlobe version 1.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For more details, head over to [the documentation website](https://brainglobe.in
 
 At a glance:
 
-- There is a [command-line interface](https://brainglobe.info/documentation/cellfinder/user-guide/command-line/index.html) that integrates [with `brainreg`](https://github.com/brainglobe/brainreg) for automated cell detection and classification.
+- There is a command-line interface called [brainmapper](https://brainglobe.info/documentation/brainglobe-workflows/brainmapper/index.html) that integrates [with `brainreg`](https://github.com/brainglobe/brainreg) for automated cell detection and classification. You can install it through [`brainglobe-workflows`](https://brainglobe.info/documentation/brainglobe-workflows/index.html).
 - There is a [napari plugin](https://brainglobe.info/documentation/cellfinder/user-guide/napari-plugin/index.html) for interacting graphically with the cellfinder tool.
 - There is a [Python API](https://brainglobe.info/documentation/cellfinder/user-guide/cellfinder-core.html) to allow users to integrate BrainGlobe tools into their custom workflows.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Topic :: Scientific/Engineering :: Image Recognition",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "brainglobe-utils",
     "dask[array]",


### PR DESCRIPTION
## Minor metadata updates

- Drop python 3.8 official support
- Point README to brainmapper information, rather than old cellfinder-CLI

## Reinstate the CI check for `brainmapper`

For the release of v1.0.0 we had to suppress the check on the `brainmapper` command-line interface, since we had a circular dependency:

Workflows needs cellfinder v1.0.0 on PyPI to download it and test-run brainmapper -> cellfinder v1.0.0 can't check that brainmapper works since it needs the name available in workflows.

This PR reinstates the command-line tool check in our CI workflow.
This is something of a code duplication (ideally the CI in this repo would call some CI in workflows) but it safeguards us for now, and we can always set this up ourselves after the migration is complete.

## Won't work until brainglobe-workflows is released with brainmapper available.