### PR TITLE
Test Keras is present

### DIFF
--- a/.github/workflows/test_include_guard.yaml
+++ b/.github/workflows/test_include_guard.yaml
@@ -35,8 +35,8 @@ jobs:
             import cellfinder.core
             import cellfinder.napari
 
-      - name: Uninstall tensorflow
-        run: python -m pip uninstall -y tensorflow
+      - name: Uninstall keras
+        run: python -m pip uninstall -y keras
 
       - name: Test (broken) import
         id: broken_import

--- a/cellfinder/__init__.py
+++ b/cellfinder/__init__.py
@@ -5,20 +5,17 @@ try:
 except PackageNotFoundError as e:
     raise PackageNotFoundError("cellfinder package not installed") from e
 
-# If tensorflow is not present, tools cannot be used.
+# If Keras is not present with a backend, tools cannot be used.
 # Throw an error in this case to prevent invocation of functions.
 try:
-    TF_VERSION = version("tensorflow")
+    KERAS_VERSION = version("keras")  # replace by keras?
 except PackageNotFoundError as e:
-    try:
-        TF_VERSION = version("tensorflow-macos")
-    except PackageNotFoundError as e:
-        raise PackageNotFoundError(
-            f"cellfinder tools cannot be invoked without tensorflow. "
-            f"Please install tensorflow into your environment to use cellfinder tools. "
-            f"For more information, please see "
-            f"https://github.com/brainglobe/brainglobe-meta#readme."
-        ) from e
+    raise PackageNotFoundError(
+        f"cellfinder tools cannot be invoked without Keras. "
+        f"Please install tensorflow into your environment to use cellfinder tools. "
+        f"For more information, please see "
+        f"https://github.com/brainglobe/brainglobe-meta#readme."
+    ) from e
 
 __author__ = "Adam Tyson, Christian Niedworok, Charly Rousseau"
 __license__ = "BSD-3-Clause"

--- a/cellfinder/__init__.py
+++ b/cellfinder/__init__.py
@@ -8,7 +8,7 @@ except PackageNotFoundError as e:
 # If Keras is not present with a backend, tools cannot be used.
 # Throw an error in this case to prevent invocation of functions.
 try:
-    KERAS_VERSION = version("keras")  # replace by keras?
+    KERAS_VERSION = version("keras")
 except PackageNotFoundError as e:
     raise PackageNotFoundError(
         f"cellfinder tools cannot be invoked without Keras. "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,9 +29,8 @@ dependencies = [
     "numpy",
     "scikit-image",
     "scikit-learn",
-    # See https://github.com/brainglobe/cellfinder-core/issues/103 for < 2.12.0 pin
-    "tensorflow-macos>=2.5.0,<2.12.0; platform_system=='Darwin' and platform_machine=='arm64'",
-    "tensorflow>=2.5.0,<2.12.0; platform_system!='Darwin' or platform_machine!='arm64'",
+    "keras",
+    "tf-nightly==2.16.0.dev20240101", # pinning to same TF as Keras 3.0
     "tifffile",
     "tqdm",
 ]
@@ -124,7 +123,6 @@ commands = python -m pytest -v --color=yes
 deps =
     pytest
     pytest-cov
-    pytest-lazy-fixture
     pytest-mock
     pytest-timeout
     # Even though napari is a requirement for cellfinder.napari, we have to


### PR DESCRIPTION
This PR:
- Updates the dependencies and dev dependencies to work with Keras 3.0
- Replaces the Tensorflow check with a Keras check (tested in CI).

**Notes:**
- To avoid TF [overwriting](https://keras.io/getting_started/#installing-keras-3) the Keras version to 2.x, I pinned the TF version to a specific 2.16-nightly for now (same as they do in the [keras repo](https://github.com/keras-team/keras/blob/master/requirements.txt)).
- Before migrating to Keras 3.0, we checked that cellfinder tools throw an error if Tensorflow is not present. This PR replaces this check with an equivalent check for Keras.
- The CI checks that are failing (running package tests, brainmapper tests and running tests without numba) are dealt with in a [follow-up PR](https://github.com/brainglobe/cellfinder/pull/373).

**Question for reviewer**: 
Keras still needs a backend to work (for now tensorflow) - should we also check that one backend is defined? More on setting the backend [here](https://keras.io/getting_started/#configuring-your-backend).