### PR TITLE
Replace TF references in comments and warning messages

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -48,8 +48,8 @@ jobs:
           python-version: "3.10"
 
     steps:
-      # Cache the tensorflow model so we don't have to remake it every time
-      - name: Cache tensorflow model
+      # Cache the Keras model so we don't have to remake it every time
+      - name: Cache Keras model
         uses: actions/cache@v3
         with:
           path: "~/.cellfinder"
@@ -73,7 +73,7 @@ jobs:
        NUMBA_DISABLE_JIT: "1"
 
     steps:
-      - name: Cache tensorflow model
+      - name: Cache Keras model
         uses: actions/cache@v3
         with:
           path: "~/.cellfinder"
@@ -96,7 +96,7 @@ jobs:
     name: Run brainmapper tests to check for breakages
     runs-on: ubuntu-latest
     steps:
-      - name: Cache tensorflow model
+      - name: Cache Keras model
         uses: actions/cache@v3
         with:
           path: "~/.cellfinder"

--- a/.github/workflows/test_include_guard.yaml
+++ b/.github/workflows/test_include_guard.yaml
@@ -1,5 +1,5 @@
-name: Test Tensorflow include guards
-# These tests check that the include guards checking for tensorflow's availability
+name: Test Keras include guards
+# These tests check that the include guards checking for Keras availability
 # behave as expected on ubuntu and macOS.
 
 on:
@@ -9,7 +9,7 @@ on:
       - main
 
 jobs:
-  tensorflow_guards:
+  keras_guards:
     name: Test include guards
     strategy:
       matrix:

--- a/cellfinder/__init__.py
+++ b/cellfinder/__init__.py
@@ -12,7 +12,7 @@ try:
 except PackageNotFoundError as e:
     raise PackageNotFoundError(
         f"cellfinder tools cannot be invoked without Keras. "
-        f"Please install tensorflow into your environment to use cellfinder tools. "
+        f"Please install Keras into your environment to use cellfinder tools. "
         f"For more information, please see "
         f"https://github.com/brainglobe/brainglobe-meta#readme."
     ) from e


### PR DESCRIPTION
Changed some missed referenced to tensorflow -> Keras.

Changes are in github worklows (job names), some comments and in warning/error messages.