### PR TITLE
Cellfinder with Keras 3.0 and jax backend

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -115,8 +115,10 @@ jobs:
       - name: Install test dependencies
         run: |
           python -m pip install --upgrade pip wheel
-          # Install latest SHA on this brainglobe-workflows branch
+          # Install cellfinder from the latest SHA on this branch
           python -m pip install git+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA
+          # Install tensorflow as keras' default backend
+          python -m pip install "tf-nightly==2.16.0.dev20240101"
           # Install checked out copy of brainglobe-workflows
           python -m pip install .[dev]
 

--- a/.github/workflows/test_include_guard.yaml
+++ b/.github/workflows/test_include_guard.yaml
@@ -24,7 +24,7 @@ jobs:
         with:
           python-version: '3.10'
 
-      - name: Install via pip using tensorflow backend
+      - name: Install cellfinder via pip, specifying tensorflow as keras' backend
         run: python -m pip install -e ".[tf-backend]"
 
       - name: Test (working) import

--- a/.github/workflows/test_include_guard.yaml
+++ b/.github/workflows/test_include_guard.yaml
@@ -24,8 +24,8 @@ jobs:
         with:
           python-version: '3.10'
 
-      - name: Install via pip
-        run: python -m pip install -e .
+      - name: Install via pip using tensorflow backend
+        run: python -m pip install -e ".[tf-backend]"
 
       - name: Test (working) import
         uses: jannekem/run-python-script-action@v1

--- a/.github/workflows/test_include_guard.yaml
+++ b/.github/workflows/test_include_guard.yaml
@@ -25,7 +25,7 @@ jobs:
           python-version: '3.10'
 
       - name: Install cellfinder via pip, specifying tensorflow as keras' backend
-        run: python -m pip install -e ".[tf-backend]"
+        run: python -m pip install -e ".[tf]"
 
       - name: Test (working) import
         uses: jannekem/run-python-script-action@v1

--- a/cellfinder/__init__.py
+++ b/cellfinder/__init__.py
@@ -5,7 +5,7 @@ try:
 except PackageNotFoundError as e:
     raise PackageNotFoundError("cellfinder package not installed") from e
 
-# If Keras is not present with a backend, tools cannot be used.
+# If Keras is not present, tools cannot be used.
 # Throw an error in this case to prevent invocation of functions.
 try:
     KERAS_VERSION = version("keras")
@@ -16,6 +16,22 @@ except PackageNotFoundError as e:
         f"For more information, please see "
         f"https://github.com/brainglobe/brainglobe-meta#readme."
     ) from e
+
+# Configure Keras backend:
+# Note that Keras should only be imported after the backend
+# has been configured. The backend cannot be changed once the
+# package is imported.
+# https://keras.io/getting_started/intro_to_keras_for_engineers/
+# https://github.com/keras-team/keras/blob/5bc8488c0ea3f43c70c70ebca919093cd56066eb/keras/backend/config.py#L263
+try:
+    import os
+
+    # check if environment variable exists?
+    os.environ["KERAS_BACKEND"] = "jax"  # "torch" "jax", "tensorflow"
+
+except PackageNotFoundError as e:
+    raise PackageNotFoundError("error setting up Keras backend") from e
+
 
 __author__ = "Adam Tyson, Christian Niedworok, Charly Rousseau"
 __license__ = "BSD-3-Clause"

--- a/cellfinder/__init__.py
+++ b/cellfinder/__init__.py
@@ -1,5 +1,8 @@
+import os
+import warnings
 from importlib.metadata import PackageNotFoundError, version
 
+# Check cellfinder is installed
 try:
     __version__ = version("cellfinder")
 except PackageNotFoundError as e:
@@ -12,26 +15,36 @@ try:
 except PackageNotFoundError as e:
     raise PackageNotFoundError(
         f"cellfinder tools cannot be invoked without Keras. "
-        f"Please install Keras into your environment to use cellfinder tools. "
-        f"For more information, please see "
+        f"Please install Keras with a backend into your environment "
+        f"to use cellfinder tools. "
+        f"For more information on Keras backends, please see "
+        f"https://keras.io/getting_started/#installing-keras-3."
+        f"For more information on brainglobe, please see "
         f"https://github.com/brainglobe/brainglobe-meta#readme."
     ) from e
 
-# Configure Keras backend:
-# Note that Keras should only be imported after the backend
-# has been configured. The backend cannot be changed once the
-# package is imported.
-try:
-    import os
 
-    # if environment variable does not exist, assign TF
-    # options: "torch" "jax", "tensorflow"
-    if not os.getenv("KERAS_BACKEND"):
-        os.environ["KERAS_BACKEND"] = "tensorflow"
+# If no backend is configured and installed for Keras, tools cannot be used
+# Check backend is configured
+if not os.getenv("KERAS_BACKEND"):
+    os.environ["KERAS_BACKEND"] = "tensorflow"
+    warnings.warn(
+        "Keras backend not configured, automatically set to Tensorflow"
+    )
 
-
-except PackageNotFoundError as e:
-    raise PackageNotFoundError("error setting up Keras backend") from e
+# Check backend is installed
+if os.getenv("KERAS_BACKEND") in ["tensorflow", "jax", "torch"]:
+    backend = os.getenv("KERAS_BACKEND")
+    try:
+        BACKEND_VERSION = version(backend)
+    except PackageNotFoundError as e:
+        raise PackageNotFoundError(
+            f"{backend} package set as Keras backend but not installed"
+        ) from e
+else:
+    raise PackageNotFoundError(
+        "Keras backend must be one of 'tensorflow', 'jax', or 'torch'"
+    )
 
 
 __author__ = "Adam Tyson, Christian Niedworok, Charly Rousseau"

--- a/cellfinder/__init__.py
+++ b/cellfinder/__init__.py
@@ -26,8 +26,11 @@ except PackageNotFoundError as e:
 try:
     import os
 
-    # check if environment variable exists?
-    os.environ["KERAS_BACKEND"] = "jax"  # "torch" "jax", "tensorflow"
+    # check if environment variable exists, otherwise set to tensorflow?
+    if not os.getenv("KERAS_BACKEND"):
+        os.environ[
+            "KERAS_BACKEND"
+        ] = "tensorflow"  # "torch" "jax", "tensorflow"
 
 except PackageNotFoundError as e:
     raise PackageNotFoundError("error setting up Keras backend") from e

--- a/cellfinder/__init__.py
+++ b/cellfinder/__init__.py
@@ -36,10 +36,12 @@ if not os.getenv("KERAS_BACKEND"):
 if os.getenv("KERAS_BACKEND") in ["tensorflow", "jax", "torch"]:
     backend = os.getenv("KERAS_BACKEND")
     try:
-        BACKEND_VERSION = version(backend)
+        backend_package = "tf-nightly" if backend == "tensorflow" else backend
+        BACKEND_VERSION = version(backend_package)
     except PackageNotFoundError as e:
         raise PackageNotFoundError(
-            f"{backend} package set as Keras backend but not installed"
+            f"{backend} package ({backend_package}) set as Keras backend "
+            f"but not installed"
         ) from e
 else:
     raise PackageNotFoundError(

--- a/cellfinder/__init__.py
+++ b/cellfinder/__init__.py
@@ -40,7 +40,7 @@ if os.getenv("KERAS_BACKEND") in ["tensorflow", "jax", "torch"]:
         BACKEND_VERSION = version(backend_package)
     except PackageNotFoundError as e:
         raise PackageNotFoundError(
-            f"{backend} package ({backend_package}) set as Keras backend "
+            f"{backend}, ({backend_package}) set as Keras backend "
             f"but not installed"
         ) from e
 else:

--- a/cellfinder/__init__.py
+++ b/cellfinder/__init__.py
@@ -21,16 +21,14 @@ except PackageNotFoundError as e:
 # Note that Keras should only be imported after the backend
 # has been configured. The backend cannot be changed once the
 # package is imported.
-# https://keras.io/getting_started/intro_to_keras_for_engineers/
-# https://github.com/keras-team/keras/blob/5bc8488c0ea3f43c70c70ebca919093cd56066eb/keras/backend/config.py#L263
 try:
     import os
 
-    # check if environment variable exists, otherwise set to tensorflow?
+    # if environment variable does not exist, assign TF
+    # options: "torch" "jax", "tensorflow"
     if not os.getenv("KERAS_BACKEND"):
-        os.environ[
-            "KERAS_BACKEND"
-        ] = "tensorflow"  # "torch" "jax", "tensorflow"
+        os.environ["KERAS_BACKEND"] = "tensorflow"
+
 
 except PackageNotFoundError as e:
     raise PackageNotFoundError("error setting up Keras backend") from e

--- a/cellfinder/core/classify/resnet.py
+++ b/cellfinder/core/classify/resnet.py
@@ -1,7 +1,7 @@
 from typing import Callable, Dict, List, Literal, Optional, Tuple, Union
 
 from keras import (
-    KerasTensor as Tensor,  # from tensorflow import Tensor  # tf.Tensor
+    KerasTensor as Tensor,
 )
 from keras import Model
 from keras.initializers import Initializer

--- a/cellfinder/core/classify/resnet.py
+++ b/cellfinder/core/classify/resnet.py
@@ -1,5 +1,8 @@
 from typing import Callable, Dict, List, Literal, Optional, Tuple, Union
 
+from keras import (
+    KerasTensor as Tensor,  # from tensorflow import Tensor  # tf.Tensor
+)
 from keras import Model
 from keras.initializers import Initializer
 from keras.layers import (
@@ -14,7 +17,6 @@ from keras.layers import (
     ZeroPadding3D,
 )
 from keras.optimizers import Adam, Optimizer
-from tensorflow import Tensor
 
 #####################################################################
 # Define the types of ResNet

--- a/cellfinder/core/tools/prep.py
+++ b/cellfinder/core/tools/prep.py
@@ -28,13 +28,12 @@ def prep_model_weights(
     model_name: model_download.model_type,
     n_free_cpus: int,
 ) -> Path:
-    # if TF backend:
+    # if tensorflow backend: do required prep
     if keras.config.backend() == "tensorflow":
-        # prep TF
         n_processes = get_num_processes(min_free_cpu_cores=n_free_cpus)
         prep_tensorflow(n_processes)
 
-    # prep models (get default weights or provided ones?)
+    # prepare models (get default weights or provided ones)
     model_weights = prep_models(model_weights, install_path, model_name)
 
     return model_weights

--- a/cellfinder/core/tools/prep.py
+++ b/cellfinder/core/tools/prep.py
@@ -3,10 +3,12 @@ prep
 ==================
 Functions to prepare files and directories needed for other functions
 """
+
 import os
 from pathlib import Path
 from typing import Optional
 
+import keras
 from brainglobe_utils.general.config import get_config_obj
 from brainglobe_utils.general.system import get_num_processes
 
@@ -26,8 +28,13 @@ def prep_model_weights(
     model_name: model_download.model_type,
     n_free_cpus: int,
 ) -> Path:
-    n_processes = get_num_processes(min_free_cpu_cores=n_free_cpus)
-    prep_tensorflow(n_processes)
+    # if TF backend:
+    if keras.config.backend() == "tensorflow":
+        # prep TF
+        n_processes = get_num_processes(min_free_cpu_cores=n_free_cpus)
+        prep_tensorflow(n_processes)
+
+    # prep models (get default weights or provided ones?)
     model_weights = prep_models(model_weights, install_path, model_name)
 
     return model_weights
@@ -44,7 +51,8 @@ def prep_models(
     model_name: model_download.model_type,
 ) -> Path:
     install_path = install_path or DEFAULT_INSTALL_PATH
-    # if no model or weights, set default weights
+
+    # if no model or weights, set to default weights
     if model_weights_path is None:
         logger.debug("No model supplied, so using the default")
 

--- a/cellfinder/core/tools/tf.py
+++ b/cellfinder/core/tools/tf.py
@@ -1,5 +1,3 @@
-import tensorflow as tf
-
 from cellfinder.core import logger
 
 
@@ -9,6 +7,8 @@ def allow_gpu_memory_growth():
     away. Allows multiple processes to use the GPU (and avoid occasional
     errors on some systems) at the cost of a slight performance penalty.
     """
+    import tensorflow as tf  # import inside fns?
+
     gpus = tf.config.experimental.list_physical_devices("GPU")
     if gpus:
         logger.debug("Allowing GPU memory growth")
@@ -37,6 +37,8 @@ def set_tf_threads(max_threads):
         f"Setting maximum number of threads for tensorflow "
         f"to: {max_threads}"
     )
+
+    import tensorflow as tf  # import inside fns?
 
     # If statements are for testing. If tf is initialised, then setting these
     # parameters throws an error

--- a/cellfinder/core/tools/tf.py
+++ b/cellfinder/core/tools/tf.py
@@ -7,7 +7,7 @@ def allow_gpu_memory_growth():
     away. Allows multiple processes to use the GPU (and avoid occasional
     errors on some systems) at the cost of a slight performance penalty.
     """
-    import tensorflow as tf  # import inside fns?
+    import tensorflow as tf
 
     gpus = tf.config.experimental.list_physical_devices("GPU")
     if gpus:
@@ -38,7 +38,7 @@ def set_tf_threads(max_threads):
         f"to: {max_threads}"
     )
 
-    import tensorflow as tf  # import inside fns?
+    import tensorflow as tf
 
     # If statements are for testing. If tf is initialised, then setting these
     # parameters throws an error

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,14 +59,15 @@ napari = [
     "pooch >= 1",
     "qtpy",
 ]
-tf-backend = [
+# Keras backends
+tf = [
     "tf-nightly==2.16.0.dev20240101", # pinning to same TF as Keras 3.0
 ]
-jax-backend = [
+jax = [
     "jax==0.4.20",
     "jaxlib==0.4.20"
 ]
-torch-backend = [
+torch = [
     "torch==2.1.0"
 ]
 
@@ -140,8 +141,8 @@ deps =
     pytest-qt
 extras =
     napari
-    tf: tf-backend
-    jax: jax-backend
+    tf: tf
+    jax: jax
 setenv =
     tf: KERAS_BACKEND = tensorflow
     jax: KERAS_BACKEND = jax

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,7 @@ dependencies = [
     "numpy",
     "scikit-image",
     "scikit-learn",
-    "keras",
-    "tf-nightly==2.16.0.dev20240101", # pinning to same TF as Keras 3.0
+    "keras==3.0.0",
     "tifffile",
     "tqdm",
 ]
@@ -59,6 +58,16 @@ napari = [
     "napari[pyqt5]",
     "pooch >= 1",
     "qtpy",
+]
+tf_backend = [
+    "tf-nightly==2.16.0.dev20240101", # pinning to same TF as Keras 3.0 --> tensorflow==2.15.0 and keras==3.0.0
+]
+jax_backend = [
+    "jax==0.4.20",
+    "jaxlib==0.4.20"
+]
+torch_backend = [
+    "torch==2.1.0"
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,13 +119,13 @@ markers = ["slow: marks tests as slow (deselect with '-m \"not slow\"')"]
 legacy_tox_ini = """
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{39,310}
+envlist = py{39,310}-{tf,jax}
 isolated_build = true
 
 [gh-actions]
 python =
-    3.9: py39
-    3.10: py310
+    3.9: py39-{tf,jax}  # On GA python=3.9 job, run tox with the tf and jax environments
+    3.10: py310-{tf,jax}  # On GA python=3.10 job, run tox with the tf and jax environments
 
 [testenv]
 commands = python -m pytest -v --color=yes
@@ -140,7 +140,11 @@ deps =
     pytest-qt
 extras =
     napari
-    tf-backend
+    tf: tf-backend
+    jax: jax-backend
+setenv =
+    tf: KERAS_BACKEND = tensorflow
+    jax: KERAS_BACKEND = jax
 passenv =
     NUMBA_DISABLE_JIT
     CI
@@ -149,5 +153,4 @@ passenv =
     XAUTHORITY
     NUMPY_EXPERIMENTAL_ARRAY_FUNCTION
     PYVISTA_OFF_SCREEN
-    KERAS_BACKEND
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "numpy",
     "scikit-image",
     "scikit-learn",
-    "keras==3.0.0",
+    "keras>=3.0.0",
     "tifffile",
     "tqdm",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,14 +59,14 @@ napari = [
     "pooch >= 1",
     "qtpy",
 ]
-tf_backend = [
-    "tf-nightly==2.16.0.dev20240101", # pinning to same TF as Keras 3.0 --> tensorflow==2.15.0 and keras==3.0.0
+tf-backend = [
+    "tf-nightly==2.16.0.dev20240101", # pinning to same TF as Keras 3.0
 ]
-jax_backend = [
+jax-backend = [
     "jax==0.4.20",
     "jaxlib==0.4.20"
 ]
-torch_backend = [
+torch-backend = [
     "torch==2.1.0"
 ]
 
@@ -140,6 +140,7 @@ deps =
     pytest-qt
 extras =
     napari
+    tf-backend
 passenv =
     NUMBA_DISABLE_JIT
     CI
@@ -148,4 +149,5 @@ passenv =
     XAUTHORITY
     NUMPY_EXPERIMENTAL_ARRAY_FUNCTION
     PYVISTA_OFF_SCREEN
+    KERAS_BACKEND
 """


### PR DESCRIPTION
With this PR, cellfinder tests pass with Keras 3.0 and both the tensorflow and the JAX backend 🥳 

Specifically:
- I added checks similar to previously existing ones, that checked if `tensorflow` was installed in the environment before importing `cellfinder`. Now we check if `keras` is installed, and if it has an appropriate backend installed. I modified the CI check accordingly.

- I configured tox to run tests using the tensorflow backend and the JAX backend.

- for the brainmapper tests we run in CI, I added a `pip install` step that installs the (for now pinned) tensorflow version compatible with Keras 3.0.0. I am (temporarily) setting tensorflow as the default backend for Keras if none is defined.

- for the time being I pinned Keras and TF to specific versions, but happy to inspect that further in a future PR (in theory TF 2.15 [should be compatible](https://keras.io/getting_started/#compatibility-matrix) with Keras 3.0.0)