### PR TITLE
Switch order of arguments passed to prep_model_weights in train_yml.py

### DIFF
--- a/cellfinder/core/train/train_yml.py
+++ b/cellfinder/core/train/train_yml.py
@@ -338,7 +338,7 @@ def run(
 
     ensure_directory_exists(output_dir)
     model_weights = prep_model_weights(
-        install_path, model_weights, model, n_free_cpus
+        model_weights, install_path, model, n_free_cpus
     )
 
     yaml_contents = parse_yaml(yaml_file)

--- a/cellfinder/core/train/train_yml.py
+++ b/cellfinder/core/train/train_yml.py
@@ -338,7 +338,10 @@ def run(
 
     ensure_directory_exists(output_dir)
     model_weights = prep_model_weights(
-        model_weights, install_path, model, n_free_cpus
+        model_weights=model_weights,
+        install_path=install_path,
+        model_name=model,
+        n_free_cpus=n_free_cpus,
     )
 
     yaml_contents = parse_yaml(yaml_file)


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Trying to continue training without passing a trained model/model weights was leading to a crash.

**What does this PR do?**
Fixes the order arguments are passed to `prep_model_weights` in `cellfinder/core/train/train_yml.py` to match with the rest of the codebase.

## References

Please reference any existing issues/PRs that relate to this PR.

## How has this PR been tested?

All previous tests pass locally on Ubuntu.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
