### PR TITLE
Pin minimum brainglobe dependency versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,8 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "brainglobe-utils",
-    "brainglobe-napari-io",
+    "brainglobe-utils>=0.4.2",
+    "brainglobe-napari-io>=0.3.4",
     "dask[array]",
     "fancylog>=0.0.7",
     "natsort",


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [X] Other

**Why is this PR needed?**
`brainglobe-utils` and `brainglobe-napari-io` currently don't have minimum pinned versions.

**What does this PR do?**
This PR pins the minimum `brainglobe-utils` version to 0.4.2, and `brainglobe-napari-io` to 0.3.4

## References

## How has this PR been tested?

All tests pass locally.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [X] The code has been tested locally
- [X] Tests have been added to cover all new functionality (unit & integration)
- [X] The documentation has been updated to reflect any changes
- [X] The code has been formatted with [pre-commit](https://pre-commit.com/)
