### PR TITLE
Adapt CI so it covers both new and old Macs, and installs required additional dependencies on M1

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -42,12 +42,14 @@ jobs:
         # Run all supported Python versions on linux
         os: [ubuntu-latest]
         python-version: ["3.9", "3.10"]
-        # Include one windows, one macos run
+        # Include one windows, one macos run each for M1 (latest) and Intel (13)
         include:
-        - os: macos-latest
-          python-version: "3.10"
-        - os: windows-latest
-          python-version: "3.10"
+          - os: macos-13
+            python-version: "3.10"
+          - os: macos-latest
+            python-version: "3.10"
+          - os: windows-latest
+            python-version: "3.10"
 
     steps:
       # Cache the tensorflow model so we don't have to remake it every time
@@ -61,6 +63,12 @@ jobs:
         uses: tlambert03/setup-qt-libs@v1
       # Setup VTK with headless display
       - uses: pyvista/setup-headless-display-action@v2
+      # install additional Macos dependencies
+      - name: install HDF5 libraries
+        if: matrix.os == 'macos-latest'
+        run: |
+          brew install hdf5
+          export PATH="/usr/local/opt/hdf5/bin:$PATH"
       # Run all tests
       - uses: neuroinformatics-unit/actions/test@v2
         with:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -63,12 +63,6 @@ jobs:
         uses: tlambert03/setup-qt-libs@v1
       # Setup VTK with headless display
       - uses: pyvista/setup-headless-display-action@v2
-      # install additional Macos dependencies
-      - name: install HDF5 libraries
-        if: matrix.os == 'macos-latest'
-        run: |
-          brew install hdf5
-          export PATH="/usr/local/opt/hdf5/bin:$PATH"
       # Run all tests
       - uses: neuroinformatics-unit/actions/test@v2
         with:

--- a/.github/workflows/test_include_guard.yaml
+++ b/.github/workflows/test_include_guard.yaml
@@ -35,7 +35,12 @@ jobs:
             import cellfinder.core
             import cellfinder.napari
 
-      - name: Uninstall tensorflow
+      - name: Uninstall tensorflow-macos on Mac M1
+        if: matrix.os == 'macos-latest'
+        run: python -m pip uninstall -y tensorflow-macos
+
+      - name: Uninstall tensorflow on Ubuntu
+        if: matrix.os == 'ubuntu-latest'
         run: python -m pip uninstall -y tensorflow
 
       - name: Test (broken) import


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

`macos-latest` is now a Silicon Mac runner, so we need to adapt CI accordingly

**What does this PR do?**
* ensures CI is run on both Mac chip architectures
* runs tensorflow include guard tests on Silicon mac instead.

## References

Partial solution to https://github.com/brainglobe/BrainGlobe/issues/63

## How has this PR been tested?

CI that was breaking before, now passes

## Is this a breaking change?

Now

## Does this PR require an update to the documentation?

No

## Checklist:

- [n/a] The code has been tested locally
- [n/a] Tests have been added to cover all new functionality (unit & integration)
- [n/a] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
