### PR TITLE
Add timeout and continue on error flags to numba disabled tests

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -73,7 +73,7 @@ jobs:
   test_numba_disabled:
     needs: [linting, manifest]
     name: Run tests with numba disabled
-    timeout-minutes: 60
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
        NUMBA_DISABLE_JIT: "1"
@@ -91,6 +91,7 @@ jobs:
       - uses: pyvista/setup-headless-display-action@v2
       # Run test suite with numba disabled
       - uses: neuroinformatics-unit/actions/test@v2
+        continue-on-error: true
         with:
           python-version: "3.10"
           secret-codecov-token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
Tests sporadically fail when numba is disabled. These tests are only used to provide coverage so their failure should not block merging.

**What does this PR do?**
Adds a `continue-on-error` flag to the numba disabled tests, changes the timeout to be 30 mins.

## References
#404 .

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
