### PR TITLE
Moved force cpu into cellfinder function

### DIFF
--- a/cellfinder/core/tools/system.py
+++ b/cellfinder/core/tools/system.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import keras
 from brainglobe_utils.general.exceptions import CommandLineInputError
 
 
@@ -80,3 +81,12 @@ def memory_in_bytes(memory_amount, unit):
         )
     else:
         return memory_amount * 10 ** supported_units[unit]
+
+
+def force_cpu():
+    """
+    Forces the CPU to be used, even if a GPU is available
+    """
+    keras.src.backend.common.global_state.set_global_attribute(
+        "torch_device", "cpu"
+    )

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -1,7 +1,6 @@
 import os
 from typing import Tuple
 
-import keras.src.backend.common.global_state
 import numpy as np
 import pytest
 import torch.backends.mps
@@ -11,6 +10,7 @@ from cellfinder.core.download.download import (
     DEFAULT_DOWNLOAD_DIRECTORY,
     download_models,
 )
+from cellfinder.core.tools.system import force_cpu
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -24,9 +24,7 @@ def set_device_arm_macos_ci():
         os.getenv("GITHUB_ACTIONS") == "true"
         and torch.backends.mps.is_available()
     ):
-        keras.src.backend.common.global_state.set_global_attribute(
-            "torch_device", "cpu"
-        )
+        force_cpu()
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Tests in `brainglobe-workflows` fail on macos-latest as they attempt to run using `mps` which is not available on github runners even though `torch.backends.mps.is_available()` returns `True`.

**What does this PR do?**
Moves the logic for forcing PyTorch to use the cpu as the device into the `cellfinder` package. This will hopefully allow the fix from this repo to generalise to `brainglobe-workflows`.

## How has this PR been tested?
Tested on CI (only place I can reproduce this issue).

## Is this a breaking change?
No

## Does this PR require an update to the documentation?
No

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
