### PR TITLE
Remove test dependency duplication

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,16 +122,8 @@ python =
 
 [testenv]
 commands = python -m pytest -v --color=yes --cov=cellfinder --cov-report=xml
-deps =
-    pytest
-    pytest-cov
-    pytest-mock
-    pytest-timeout
-    # Even though napari is a requirement for cellfinder.napari, we have to
-    # ensure it is installed with the default Qt backend here.
-    napari[all]
-    pytest-qt
 extras =
+    dev
     napari
 setenv =
     KERAS_BACKEND = torch


### PR DESCRIPTION
We shouldn't need to define test dependencies in tox. This PR relies on installing the `dev` and `napari` extras, so hopefully we have one less thing to keep up to date.

Closes https://github.com/brainglobe/cellfinder/issues/284