### PR TITLE
Unpin numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
     "fancylog>=0.0.7",
     "natsort",
     "numba",
-    "numpy<2.0.0; sys_platform=='win32'",
     "numpy",
     "scikit-image",
     "scikit-learn",


### PR DESCRIPTION
In theory this should now be fine as torch 2.4.1 has been released.

Closes #446 