### PR TITLE
Pin `keras` version to 3.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "numpy",
     "scikit-image",
     "scikit-learn",
-    "keras>=3.5.0",
+    "keras==3.5.0",
     "torch>=2.1.0",
     "tifffile",
     "tqdm",


### PR DESCRIPTION
Currently, training enters an infinite loop at the end of an epoch.

This only happens with `keras==3.6.0`. Temporarily pinning to `3.5.0`.