### PR TITLE
Unpin keras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "numpy",
     "scikit-image",
     "scikit-learn",
-    "keras==3.5.0",
+    "keras>=3.7.0",
     "torch>=2.1.0,!=2.4",
     "tifffile",
     "tqdm",


### PR DESCRIPTION
`keras` 3.7.0 fixed the stalled training bug.

closes #463 

