### PR TITLE
Use explicit len(arr)-count instead of just -count to handle count=0

### DIFF
--- a/cellfinder/core/detect/filters/volume/ball_filter.py
+++ b/cellfinder/core/detect/filters/volume/ball_filter.py
@@ -266,22 +266,21 @@ class BallFilter:
         """
         if self.volume.shape[0]:
             if self.volume.shape[0] < self.kernel_z_size:
-                num_remaining_with_padding = 0
+                num_remaining_with_padding = self.volume.shape[0]
             else:
                 num_remaining = self.kernel_z_size - (self.middle_z_idx + 1)
                 num_remaining_with_padding = num_remaining + self.middle_z_idx
+            remaining_start = self.volume.shape[0] - num_remaining_with_padding
 
             self.volume = torch.cat(
-                [self.volume[-num_remaining_with_padding:, :, :], planes],
+                [self.volume[remaining_start:, :, :], planes],
                 dim=0,
             )
 
             if self.inside_brain_tiles is not None:
                 self.inside_brain_tiles = torch.cat(
                     [
-                        self.inside_brain_tiles[
-                            -num_remaining_with_padding:, :, :
-                        ],
+                        self.inside_brain_tiles[remaining_start:, :, :],
                         masks,
                     ],
                     dim=0,

--- a/tests/core/test_unit/test_detect/test_filters/test_volume_filters/test_ball_filter.py
+++ b/tests/core/test_unit/test_detect/test_filters/test_volume_filters/test_ball_filter.py
@@ -1,4 +1,5 @@
 import pytest
+import torch
 
 from cellfinder.core.detect.filters.volume.ball_filter import BallFilter
 
@@ -13,6 +14,7 @@ bf_kwargs = {
     "tile_height": 10,
     "tile_width": 10,
     "dtype": "float32",
+    "torch_device": "cpu",
 }
 
 
@@ -30,8 +32,11 @@ def test_filter_not_ready():
 @pytest.mark.parametrize(
     "sizes", [(1, 0, 0), (2, 1, 0), (3, 1, 1), (4, 2, 1), (5, 2, 2), (6, 3, 2)]
 )
-def test_filter_unprocessed_planes(sizes):
+def test_filter_plane_params(sizes):
     kernel_size, start_offset, remaining = sizes
+    # we get exactly one plane out of a volume that is the same size as the
+    # kernel start_offset is index of first valid plane. Plus remaining is last
+    # index. Plus 1 is size
     assert kernel_size == start_offset + 1 + remaining
 
     kwargs = bf_kwargs.copy()
@@ -40,3 +45,43 @@ def test_filter_unprocessed_planes(sizes):
 
     assert bf.first_valid_plane == start_offset
     assert bf.remaining_planes == remaining
+
+
+@pytest.mark.parametrize("batch_size", [1, 2, 5, 10])
+@pytest.mark.parametrize("kernel_size", [1, 2, 3, 5])
+def test_filtered_planes(kernel_size, batch_size):
+    kwargs = bf_kwargs.copy()
+    kwargs["ball_z_size"] = kernel_size
+    bf = BallFilter(**kwargs, use_mask=False)
+
+    data = torch.empty(
+        (batch_size, kwargs["plane_height"], kwargs["plane_width"]),
+        dtype=getattr(torch, kwargs["dtype"]),
+        device=kwargs["torch_device"],
+    )
+
+    num_planes = 20
+    sent_planes = 0
+    gotten_planes = 0
+    num_padded_planes = kernel_size - 1
+
+    for _ in range(num_planes // batch_size):
+        bf.append(data)
+        sent_planes += batch_size
+        # volume only includes batch and some padding from end of last batch
+        assert bf.volume.shape[0] <= batch_size + kernel_size - 1
+
+        if bf.ready:
+            # no need to walk because walking only modifies the contents not
+            # size of volume
+            planes = bf.get_processed_planes()
+            # first batch is 1 or batch minus padding. Remaining is batch size
+            assert planes.shape[0] in (
+                1,
+                batch_size,
+                batch_size - num_padded_planes,
+            )
+
+            gotten_planes += planes.shape[0]
+
+    assert gotten_planes == sent_planes - num_padded_planes


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
It fixes #479 and makes #482 obsolete.

**What does this PR do?**

Before, we used the shorthand of `arr[-count:]` as a proxy for `arr[len(arr)-count:]`. The problem is with a batch size that is exactly equal the kernel size (ball z size), `count` is zero unintentionally. So `self.volume` kept growing without bound as we kept reusing the whole array instead of not appending any of the array, which was the intention.

## References

#479 and #482.

## How has this PR been tested?

Added pytests. Before the fix the test resulted in failure. Now it fully passes:

```
tests\core\test_unit\test_detect\test_filters\test_volume_filters\test_ball_filter.py FFFF............                                                                                                                                  [100%]

================================================================================================================== FAILURES ================================================================================================================== _________________________________________________________________________________________________________ test_filtered_planes[1-1] __________________________________________________________________________________________________________

kernel_size = 1, batch_size = 1

    @pytest.mark.parametrize("batch_size", [1, 2, 5, 10])
    @pytest.mark.parametrize("kernel_size", [1, 2, 3, 5])
    def test_filtered_planes(kernel_size, batch_size):
        kwargs = bf_kwargs.copy()
        kwargs["ball_z_size"] = kernel_size
        bf = BallFilter(**kwargs, use_mask=False)

        data = torch.empty(
            (batch_size, kwargs["plane_height"], kwargs["plane_width"]), dtype=getattr(torch, kwargs["dtype"]),
            device=kwargs["torch_device"],
        )

        num_planes = 20
        sent_planes = 0
        gotten_planes = 0
        num_padded_planes = kernel_size - 1

        for _ in range(num_planes // batch_size):
            bf.append(data)
            sent_planes += batch_size
            # volume should only include the batch and some padding from the end of last batch
>           assert bf.volume.shape[0] <= batch_size + kernel_size - 1
E           assert 2 <= ((1 + 1) - 1)

tests\core\test_unit\test_detect\test_filters\test_volume_filters\test_ball_filter.py:70: AssertionError
_________________________________________________________________________________________________________ test_filtered_planes[1-2] __________________________________________________________________________________________________________

kernel_size = 1, batch_size = 2

    @pytest.mark.parametrize("batch_size", [1, 2, 5, 10])
    @pytest.mark.parametrize("kernel_size", [1, 2, 3, 5])
    def test_filtered_planes(kernel_size, batch_size):
        kwargs = bf_kwargs.copy()
        kwargs["ball_z_size"] = kernel_size
        bf = BallFilter(**kwargs, use_mask=False)

        data = torch.empty(
            (batch_size, kwargs["plane_height"], kwargs["plane_width"]), dtype=getattr(torch, kwargs["dtype"]),
            device=kwargs["torch_device"],
        )

        num_planes = 20
        sent_planes = 0
        gotten_planes = 0
        num_padded_planes = kernel_size - 1

        for _ in range(num_planes // batch_size):
            bf.append(data)
            sent_planes += batch_size
            # volume should only include the batch and some padding from the end of last batch
>           assert bf.volume.shape[0] <= batch_size + kernel_size - 1
E           assert 4 <= ((2 + 1) - 1)

tests\core\test_unit\test_detect\test_filters\test_volume_filters\test_ball_filter.py:70: AssertionError
_________________________________________________________________________________________________________ test_filtered_planes[1-5] __________________________________________________________________________________________________________

kernel_size = 1, batch_size = 5

    @pytest.mark.parametrize("batch_size", [1, 2, 5, 10])
    @pytest.mark.parametrize("kernel_size", [1, 2, 3, 5])
    def test_filtered_planes(kernel_size, batch_size):
        kwargs = bf_kwargs.copy()
        kwargs["ball_z_size"] = kernel_size
        bf = BallFilter(**kwargs, use_mask=False)

        data = torch.empty(
            (batch_size, kwargs["plane_height"], kwargs["plane_width"]), dtype=getattr(torch, kwargs["dtype"]),
            device=kwargs["torch_device"],
        )

        num_planes = 20
        sent_planes = 0
        gotten_planes = 0
        num_padded_planes = kernel_size - 1

        for _ in range(num_planes // batch_size):
            bf.append(data)
            sent_planes += batch_size
            # volume should only include the batch and some padding from the end of last batch
>           assert bf.volume.shape[0] <= batch_size + kernel_size - 1
E           assert 10 <= ((5 + 1) - 1)

tests\core\test_unit\test_detect\test_filters\test_volume_filters\test_ball_filter.py:70: AssertionError
_________________________________________________________________________________________________________ test_filtered_planes[1-10] _________________________________________________________________________________________________________

kernel_size = 1, batch_size = 10

    @pytest.mark.parametrize("batch_size", [1, 2, 5, 10])
    @pytest.mark.parametrize("kernel_size", [1, 2, 3, 5])
    def test_filtered_planes(kernel_size, batch_size):
        kwargs = bf_kwargs.copy()
        kwargs["ball_z_size"] = kernel_size
        bf = BallFilter(**kwargs, use_mask=False)

        data = torch.empty(
            (batch_size, kwargs["plane_height"], kwargs["plane_width"]), dtype=getattr(torch, kwargs["dtype"]),
            device=kwargs["torch_device"],
        )

        num_planes = 20
        sent_planes = 0
        gotten_planes = 0
        num_padded_planes = kernel_size - 1

        for _ in range(num_planes // batch_size):
            bf.append(data)
            sent_planes += batch_size
            # volume should only include the batch and some padding from the end of last batch
>           assert bf.volume.shape[0] <= batch_size + kernel_size - 1
E           assert 20 <= ((10 + 1) - 1)

tests\core\test_unit\test_detect\test_filters\test_volume_filters\test_ball_filter.py:70: AssertionError
```

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
