### PR TITLE
Move qt-niu dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
     "tifffile",
     "tqdm",
     "qt-niu"
-
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,8 @@ dependencies = [
     "torch>=2.1.0,!=2.4",
     "tifffile",
     "tqdm",
+    "qt-niu"
+
 ]
 dynamic = ["version"]
 
@@ -52,7 +54,6 @@ dev = [
     "pytest",
     "tox",
     "pooch >= 1",
-    "qt-niu"
 ]
 napari = [
     "brainglobe-napari-io",


### PR DESCRIPTION
I put it into the dev dependencies by mistake. Cellfinder should be re-released once this is merged. I've yanked `1.5.0` on PyPI. 