### PR TITLE
[Feature] Run cell detection on subvolume of an image and not just select z planes #468

### DIFF
--- a/cellfinder/core/classify/cube_generator.py
+++ b/cellfinder/core/classify/cube_generator.py
@@ -292,7 +292,9 @@ class CubeGeneratorFromFile(Sequence):
         )
         return images
 
-    def __get_oriented_image(self, cell: Cell, image_stack: np.ndarray) -> np.ndarray:
+    def __get_oriented_image(
+        self, cell: Cell, image_stack: np.ndarray
+    ) -> np.ndarray:
         z_min, z_max = 0, image_stack.shape[0]
         y_min, y_max = 0, image_stack.shape[1]
         x_min, x_max = 0, image_stack.shape[2]
@@ -306,23 +308,26 @@ class CubeGeneratorFromFile(Sequence):
         image = image_stack[z_min:z_max, y0:y1, x0:x1]
 
         if image.size == 0:
-            raise ValueError("Cropped image has zero size, check bounding box and cell coordinates.")
+            raise ValueError(
+                "Cropped image has zero size, check bounding box and cell coordinates."
+            )
 
         image = np.moveaxis(image, 0, 2)
 
         if self.augment and self.augmentation_parameters:
-            image = augment(self.augmentation_parameters, image, scale_back=False)
+            image = augment(
+                self.augmentation_parameters, image, scale_back=False
+            )
 
         pixel_scalings = [
-            self.cube_height / image.shape[0],  
-            self.cube_width / image.shape[1],   
-            self.cube_depth / image.shape[2], 
+            self.cube_height / image.shape[0],
+            self.cube_width / image.shape[1],
+            self.cube_depth / image.shape[2],
         ]
 
         image = zoom(image, pixel_scalings, order=self.interpolation_order)
 
         return image
-
 
     @staticmethod
     def __get_batch_dict(cell_batch: List[Cell]) -> List[Dict[str, float]]:

--- a/cellfinder/core/classify/tools.py
+++ b/cellfinder/core/classify/tools.py
@@ -47,7 +47,9 @@ def get_model(
                 f"Setting model weights according to: {model_weights}",
             )
             if model_weights is None:
-                raise OSError("`model_weights` must be provided for inference or continued training.")
+                raise OSError(
+                    "`model_weights` must be provided for inference or continued training."
+                )
 
             try:
                 model.load_weights(model_weights)

--- a/cellfinder/core/classify/tools.py
+++ b/cellfinder/core/classify/tools.py
@@ -47,19 +47,9 @@ def get_model(
                 f"Setting model weights according to: {model_weights}",
             )
             if model_weights is None:
-                raise OSError(
-                    "`model_weights` must be provided for inference or continued training."
-                )
-
-            try:
-                model.load_weights(model_weights)
-            except ValueError as e:
-                raise ValueError(
-                    f"Error loading weights: {model_weights}. The provided weights do not match the model architecture.\n"
-                    "Ensure you are using the correct model file that corresponds to these weights."
-                ) from e
-    return model
-
+                raise OSError("`model_weights` must be provided")
+            model.load_weights(model_weights)
+        return model
 
 def make_lists(
     tiff_files: Sequence,

--- a/cellfinder/core/classify/tools.py
+++ b/cellfinder/core/classify/tools.py
@@ -47,9 +47,16 @@ def get_model(
                 f"Setting model weights according to: {model_weights}",
             )
             if model_weights is None:
-                raise OSError("`model_weights` must be provided")
-            model.load_weights(model_weights)
-        return model
+                raise OSError("`model_weights` must be provided for inference or continued training.")
+
+            try:
+                model.load_weights(model_weights)
+            except ValueError as e:
+                raise ValueError(
+                    f"Error loading weights: {model_weights}. The provided weights do not match the model architecture.\n"
+                    "Ensure you are using the correct model file that corresponds to these weights."
+                ) from e
+    return model
 
 
 def make_lists(

--- a/cellfinder/core/classify/tools.py
+++ b/cellfinder/core/classify/tools.py
@@ -51,6 +51,7 @@ def get_model(
             model.load_weights(model_weights)
         return model
 
+
 def make_lists(
     tiff_files: Sequence,
     train: bool = True,


### PR DESCRIPTION
This PR refactors the __get_oriented_image method to extract and rescale 3D image regions around a given cell without requiring explicit user-defined bounding boxes. The function now: #468 

- Dynamically determines bounding limits based on image_stack dimensions.
- Ensures the cropped region does not exceed image boundaries.
- Raises an error if the extracted region is empty.
- Supports augmentation if self.augment is enabled.
- Applies proper scaling and interpolation to maintain consistency.