### PR TITLE
Added detect subvolume crop support

### DIFF
--- a/cellfinder/core/detect/detect.py
+++ b/cellfinder/core/detect/detect.py
@@ -183,13 +183,8 @@ def main(
     # brainmapper can pass them in as str
     voxel_sizes = list(map(float, voxel_sizes))
 
-    # cropping according to entered constrains for all planes
-    cropped_signal_array = signal_array[
-        :, start_height:end_height, start_width:end_width
-    ]
-
     settings = DetectionSettings(
-        plane_shape=cropped_signal_array.shape[1:],
+        plane_shape=(end_height - start_height, end_width - start_width),
         plane_original_np_dtype=signal_array.dtype,
         voxel_sizes=voxel_sizes,
         soma_spread_factor=soma_spread_factor,
@@ -257,9 +252,7 @@ def main(
     torch.set_num_threads(settings.n_torch_comp_threads)
 
     # process the data
-    mp_3d_filter.process(
-        mp_tile_processor, cropped_signal_array, callback=callback
-    )
+    mp_3d_filter.process(mp_tile_processor, signal_array, callback=callback)
     cells = mp_3d_filter.get_results(splitting_settings)
 
     torch.set_num_threads(orig_n_threads)

--- a/cellfinder/core/detect/filters/setup_filters.py
+++ b/cellfinder/core/detect/filters/setup_filters.py
@@ -69,6 +69,24 @@ class DetectionSettings:
     (axis 1, axis 2) in the z-stack where z is the first axis.
     """
 
+    start_width: int = 0
+    """The index of first x to process, in the input data (inclusive)."""
+
+    end_width: int = 1
+    """
+    The index of the last x at which to stop processing the input data
+    (not inclusive).
+    """
+
+    start_height: int = 0
+    """The index of first y to process, in the input data (inclusive)."""
+
+    end_height: int = 1
+    """
+    The index of the last y at which to stop processing the input data
+    (not inclusive).
+    """
+
     start_plane: int = 0
     """The index of first plane to process, in the input data (inclusive)."""
 

--- a/cellfinder/core/detect/filters/volume/volume_filter.py
+++ b/cellfinder/core/detect/filters/volume/volume_filter.py
@@ -170,6 +170,10 @@ class VolumeFilter:
         """
         batch_size = self.settings.batch_size
         device = self.settings.torch_device
+        start_width = self.settings.start_width
+        end_width = self.settings.plane_width
+        start_height = self.settings.start_height
+        end_height = self.settings.plane_height
         start_plane = self.settings.start_plane
         end_plane = start_plane + self.settings.n_planes
         data_converter = self.settings.filter_data_converter_func
@@ -183,7 +187,13 @@ class VolumeFilter:
 
         for z in range(start_plane, end_plane, batch_size):
             # convert the data to the right type
-            np_data = data_converter(data[z : z + batch_size, :, :])
+            np_data = data_converter(
+                data[
+                    z : z + batch_size,
+                    start_height : start_height + end_height,
+                    start_width : start_width + end_width,
+                ]
+            )
             # if we ran out of batches, we are done!
             n = np_data.shape[0]
             assert n

--- a/tests/core/test_unit/test_detect/test_detect.py
+++ b/tests/core/test_unit/test_detect/test_detect.py
@@ -88,6 +88,27 @@ def test_main_bad_or_default_args(mocked_main):
     assert splitting_settings.torch_device == "cpu"
 
 
+def test_main_planes_crop_size(mocked_main):
+    process, get_results = mocked_main
+    main(
+        signal_array=np.empty((5, 50, 41)),
+        start_width=2,
+        end_width=40,
+        start_height=8,
+        end_height=21,
+    )
+
+    process.assert_called()
+    vol_filter, mp_tile_processor, signal_array = process.call_args.args
+    settings = vol_filter.settings
+
+    assert settings.plane_shape == (13, 38)
+    assert settings.end_height == 21
+    assert settings.end_width == 40
+    assert settings.n_planes == 5
+    assert signal_array.shape == (5, 13, 38)
+
+
 def test_main_planes_size(mocked_main):
     process, get_results = mocked_main
     main(signal_array=np.empty((5, 8, 19)), end_plane=4, start_plane=1)

--- a/tests/core/test_unit/test_detect/test_detect.py
+++ b/tests/core/test_unit/test_detect/test_detect.py
@@ -106,7 +106,6 @@ def test_main_planes_crop_size(mocked_main):
     assert settings.end_height == 21
     assert settings.end_width == 40
     assert settings.n_planes == 5
-    assert signal_array.shape == (5, 13, 38)
 
 
 def test_main_planes_size(mocked_main):


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description
There already existed the feature to select the range of planes to run detect on. But with the addition of giving the range of height and width, gives us the ability to run detect on a cropped area within the plane.
Example:
signal_array -> 3D array of size (100, 50, 20) [No. of Planes, Height, Width] and given start-plane = 1 and end-plane = 6
instead of running on the entire range of 5 planes each of size 50*20, we can now run it on specific area according to given height width range.

**What is this PR**

- [ ] Bug fix
- [X] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Adds support for cropping a subvolume, hence we can now control within the plane, the height and width to run detect on.

**What does this PR do?**
Added parameters to detect's `main()` to crop the height and width of the selected planes.

## References

Please reference any existing issues/PRs that relate to this PR.
issue #468 

## How has this PR been tested?
Yes

Please explain how any new code has been tested, and how you have ensured that no existing functionality has changed.
Added unit tests to check the additional parameters influence

## Is this a breaking change?
Might not, but I need to check napari plugins to add this functionality there as well.

If this PR breaks any existing functionality, please explain how and why.
No

## Does this PR require an update to the documentation?

If any features have changed, or have been added. Please explain how the documentation has been updated (and link to the associated PR). See [here](https://brainglobe.info/community/developers/index.html#to-improve-the-documentation) for details.

## Checklist:

- [X] The code has been tested locally
- [X] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [X] The code has been formatted with [pre-commit](https://pre-commit.com/)
