### PR TITLE
Work In Progress: Vision Transformers for classifier network

### DIFF
--- a/cellfinder/core/classify/tools.py
+++ b/cellfinder/core/classify/tools.py
@@ -7,8 +7,7 @@ import numpy as np
 from keras import Model
 
 from cellfinder.core import logger
-from cellfinder.core.classify import resnet
-from cellfinder.core.classify import vit
+from cellfinder.core.classify import resnet, vit
 
 
 def build_model(
@@ -20,7 +19,7 @@ def build_model(
     Automatically detects the type and configuration of the model to build
     :param network_depth: The type of model to build
     :param learning_rate: The learning rate to use
-    
+
     :return: A keras model
     """
     if network_depth in vit.vit_configs:

--- a/cellfinder/core/classify/tools.py
+++ b/cellfinder/core/classify/tools.py
@@ -7,13 +7,42 @@ import numpy as np
 from keras import Model
 
 from cellfinder.core import logger
-from cellfinder.core.classify.resnet import build_model, layer_type
+from cellfinder.core.classify import resnet
+from cellfinder.core.classify import vit
+
+
+def build_model(
+    network_depth: str,
+    learning_rate: float,
+    **kwargs,
+) -> Model:
+    """
+    Automatically detects the type and configuration of the model to build
+    :param network_depth: The type of model to build
+    :param learning_rate: The learning rate to use
+    
+    :return: A keras model
+    """
+    if network_depth in vit.vit_configs:
+        return vit.build_model(
+            network_depth=network_depth,
+            learning_rate=learning_rate,
+            **kwargs,
+        )
+    elif network_depth in resnet.resnet_configs:
+        return resnet.build_model(
+            network_depth=network_depth,
+            learning_rate=learning_rate,
+            **kwargs,
+        )
+    else:
+        raise ValueError(f"Unknown network depth: {network_depth}")
 
 
 def get_model(
     existing_model: Optional[os.PathLike] = None,
     model_weights: Optional[os.PathLike] = None,
-    network_depth: Optional[layer_type] = None,
+    network_depth: Optional[str] = None,
     learning_rate: float = 0.0001,
     inference: bool = False,
     continue_training: bool = False,

--- a/cellfinder/core/classify/tools.py
+++ b/cellfinder/core/classify/tools.py
@@ -28,7 +28,7 @@ def build_model(
             learning_rate=learning_rate,
             **kwargs,
         )
-    elif network_depth in resnet.resnet_configs:
+    elif network_depth in resnet.resnet_unit_blocks:
         return resnet.build_model(
             network_depth=network_depth,
             learning_rate=learning_rate,

--- a/cellfinder/core/classify/vit.py
+++ b/cellfinder/core/classify/vit.py
@@ -1,0 +1,294 @@
+from typing import Callable, Dict, List, Literal, Optional, Tuple, Union
+
+from keras import (
+    KerasTensor as Tensor,
+)
+from keras import Model
+from keras import layers
+from keras import optimizers
+from keras import ops as K
+
+
+class VITConfig:
+    num_layers: int
+    hidden_dim: int
+    num_heads: int
+    expanding_factor: int
+    patch_size: Tuple[int, int, int]
+    layer_norm_eps: float = 1e-6
+
+
+network_type = Literal[
+    "vit-4-layer",
+    "vit-8-layer",
+    "vit-12-layer",
+    "vit-24-layer",
+    "vit-32-layer",
+]
+
+
+vit_configs: Dict[network_type, VITConfig] = {
+    "vit-4-layer": VITConfig(
+        num_layers=4,
+        hidden_dim=64,
+        num_heads=8,
+        expanding_factor=4,
+        patch_size=(8, 8, 4),
+    ),
+    "vit-8-layer": VITConfig(
+        num_layers=8,
+        hidden_dim=256,
+        num_heads=8,
+        expanding_factor=4,
+        patch_size=(8, 8, 4),
+    ),
+    "vit-12-layer": VITConfig(
+        num_layers=12,
+        hidden_dim=768,
+        num_heads=8,
+        expanding_factor=4,
+        patch_size=(8, 8, 4),
+    ),
+    "vit-24-layer": VITConfig(
+        num_layers=24,
+        hidden_dim=1024,
+        num_heads=8,
+        expanding_factor=4,
+        patch_size=(8, 8, 4),
+    ),
+    "vit-32-layer": VITConfig(
+        num_layers=32,
+        hidden_dim=4096,
+        num_heads=8,
+        expanding_factor=4,
+        patch_size=(8, 8, 4),
+    ),
+}
+
+
+class PositionalEmbeddings(layers.Layer):
+    """
+    Add positional embeddings to the input tensor.
+    This seems to be not implemented in keras yet, so we have to do it
+
+    :param int embedding_dim: The dimension of the embeddings
+    """
+    def __init__(
+        self,
+        embedding_dim: int,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.embedding_dim = embedding_dim
+
+    def build(
+        self,
+        input_shape: Tuple[int],
+    ):
+        _, num_tokens, _ = input_shape
+        self.position_embedding = layers.Embedding(
+            input_dim=num_tokens, output_dim=self.embedding_dim
+        )
+        self.positions = K.arange(0, num_tokens, 1)
+
+    def call(
+        self,
+        inputs,
+    ):
+        return K.broadcast_to(
+            self.position_embedding(self.positions),
+            K.shape(inputs)
+        )
+
+
+def attention_block(
+    inputs,
+    layer_norm_eps: float,
+    num_heads: int,
+    hidden_dim: int,
+    name="attention_block",
+):
+    """
+    Apply a multi-head attention block.
+
+    :param inputs: The input tensor
+    :param layer_norm_eps: The epsilon value for the layer normalization
+    :param num_heads: The number of heads in the multi-head attention
+    :param hidden_dim: The hidden dimension of the multi-head attention
+    :param name: The name of the block
+    :return: The residual-output of the multi-head attention block
+    """
+    normalized_inputs = layers.LayerNormalization(
+        epsilon=layer_norm_eps,
+        name=f"{name}--layer_norm",
+    )(inputs)
+    return layers.MultiHeadAttention(
+        num_heads=num_heads,
+        key_dim=hidden_dim // num_heads,
+        name=f"{name}--mha"
+    )(normalized_inputs, normalized_inputs) 
+
+
+def mlp_block(
+    inputs,
+    hidden_dim: int,
+    layer_norm_eps: float,
+    expanding_factor: int,
+    name: str = "mlp_block",
+):
+    """
+    Apply a multi-layer perceptron block.
+
+    :param inputs: The input tensor
+    :param hidden_dim: The hidden dimension of the MLP
+    :param layer_norm_eps: The epsilon value for the layer normalization
+    :param expanding_factor: The factor by which the hidden dimension is
+    expanded in the MLP
+    :param name: The name of the block
+    :return: The residual-output of the MLP block
+    """
+    normalized_inputs = layers.LayerNormalization(
+        epsilon=layer_norm_eps,
+        name=f"{name}--layer_norm",
+    )(inputs)
+    hidden_states = layers.Dense(
+        units=hidden_dim * expanding_factor,
+        activation=K.gelu,
+        name=f"{name}--up",
+    )(normalized_inputs)
+    return layers.Dense(
+        units=hidden_dim,
+        name=f"{name}--down",
+    )(hidden_states)
+
+
+def transformer_block(
+    residual_stream,
+    layer_norm_eps: float = 1e-6, 
+    num_heads: int = 8,
+    hidden_dim: int = 128,
+    expanding_factor: int = 4,
+    name: str = "transformer_block",
+):
+    """
+    Apply a transformer block a.k.a. transformer layer.
+
+    :param residual_stream: The input tensor
+    :param layer_norm_eps: The epsilon value for the layer normalization
+    :param num_heads: The number of heads in the multi-head attention
+    :param hidden_dim: The hidden dimension of the multi-head attention
+    :param expanding_factor: The factor by which the hidden dimension is
+    expanded in the MLP
+    :param name: The name of the block
+    :return: The residual-output of the transformer block
+    """
+
+    attention_outputs = attention_block(
+        residual_stream,
+        layer_norm_eps=layer_norm_eps,
+        num_heads=num_heads,
+        hidden_dim=hidden_dim,
+        name=f"{name}--attention_block"
+    )
+
+    residual_stream = layers.Add()([
+        residual_stream,
+        attention_outputs
+    ])
+
+    mlp_outputs = mlp_block(
+        residual_stream,
+        hidden_dim=hidden_dim,
+        layer_norm_eps=layer_norm_eps,
+        expanding_factor=expanding_factor,
+        name=f"{name}--mlp_block",
+    )
+
+    # Skip connection
+    residual_stream = layers.Add()([
+        residual_stream,
+        mlp_outputs
+    ])
+
+    return residual_stream
+
+
+def build_model(
+    input_shape: Tuple[int, int, int, int] = (50, 50, 20, 2),
+    network_depth: network_type = "24-layer",
+    optimizer: Optional[optimizers.Optimizer] = None,
+    learning_rate: float = 0.0005,
+    loss: str = "categorical_crossentropy",
+    metrics: List[str] = ["accuracy"],
+    num_classes: int = 2,
+    embedding_dim: int = 128,
+    classification_activation: str = "softmax",
+) -> Model:
+    """
+    Build a Vision Transformer model.
+
+    Mostly follows the signature of the ResNet model, but with additional
+    parameters for the Vision Transformer.
+    """
+    config = vit_configs[network_depth]
+    
+    # Get the input layer
+    inputs = layers.Input(shape=input_shape)
+    # Create patches.
+    patches = layers.Conv3D(
+        name="patch_embedding",
+        filters=embedding_dim,
+        kernel_size=config.patch_size,
+        strides=config.patch_size,
+        padding="VALID",
+    )(inputs)
+    patches = layers.Reshape(
+        target_shape=(-1, embedding_dim)
+    )(patches)
+
+    # Add positional embeddings
+    positional_embeddings = PositionalEmbeddings(
+        embedding_dim=embedding_dim
+    )(patches)
+
+    residual_stream = layers.Add()([
+        patches,
+        positional_embeddings,
+    ])
+
+    # Create multiple layers of the Transformer block.
+    for layer_idx in range(config.num_layers):
+        residual_stream = transformer_block(
+            residual_stream,
+            num_heads=config.num_heads,
+            hidden_dim=config.hidden_dim,
+            expanding_factor=config.expanding_factor,
+            layer_norm_eps=config.layer_norm_eps,
+            name=f"transformer_block_{layer_idx}",
+        )
+
+    normalized_stream = layers.LayerNormalization(
+        epsilon=config.layer_norm_eps,
+        name="pre_logits_norm"
+    )(residual_stream)
+    flat_feature_vector = layers.GlobalAvgPool1D()(normalized_stream)
+
+    outputs = layers.Dense(
+        units=num_classes,
+        activation=classification_activation,
+    )(flat_feature_vector)
+
+    model = Model(
+        inputs=inputs,
+        outputs=outputs,
+    )
+    
+    if optimizer is None:
+        optimizer = optimizers.Adam(learning_rate=learning_rate)
+
+    model.compile(
+        optimizer,
+        loss=loss,
+        metrics=metrics,
+    )
+    return model

--- a/cellfinder/core/train/train_yaml.py
+++ b/cellfinder/core/train/train_yaml.py
@@ -44,6 +44,11 @@ models: Dict[depth_type, layer_type] = {
     "50": "50-layer",
     "101": "101-layer",
     "152": "152-layer",
+    "vit-4": "vit-4-layer",
+    "vit-8": "vit-8-layer",
+    "vit-12": "vit-12-layer",
+    "vit-24": "vit-24-layer",
+    "vit-32": "vit-32-layer",
 }
 
 


### PR DESCRIPTION
## Description

This Pull Request adds implementations of State-of-the-Art computer vision architecture to cellfinder, for classifier module, which supports only resnet now. The State-of-the-Art afaik for brain image cell classification is ViT, so I followed the Keras abstractions, and made sure it's absolutely compatible to the current codebase.

The plan for future steps:
- [x] Implement ViT in Keras
- [x] The code has been tested locally, on current tests and small dataset
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
- [ ] The model builds and trains now, but it yet needs to be trained on the full scale dataset
- [ ] Quantitative comparison with current ResNet classifier
- [ ] Performance testing
- [ ] Add support of pretrained backbone models (load backbone and continue fine-tune)
- [ ] Add support for specific ViT models (deit, dino, swan)
- [ ] Add unit tests to cover all the changes
- [ ] Add documentation
- [ ] Extend network support to 2D

Any guidance and feedback as I move forward would be highly appreciated.
@IgorTatarnikov @alessandrofelder @adamltyson How do you feel about this plan?

## References
This PR is heavily inspired by:
#### Codebases with ViTs for brain
- SoTA currently:
    - CellVIT: https://github.com/TIO-IKIM/CellViT
        - [paper](https://doi.org/10.1016/j.media.2024.103143)
    - CellVIT++: https://github.com/TIO-IKIM/CellViT-Plus-Plus
        - [paper](https://arxiv.org/abs/2501.05269)
    - TransSeg: https://github.com/yuhui-zh15/TransSeg/tree/main/src/backbones/encoders
        - [paper](https://arxiv.org/pdf/2302.04303)
#### Other
- MONAI: https://github.com/Project-MONAI/MONAI/tree/dev/monai/networks/nets
- pyradiomics: https://github.com/Meddebma/pyradiomics/blob/master/Classification_HBI_ViT.ipynb
- https://www.kaggle.com/code/super13579/vit-vision-transformer-3d-with-one-mri-type
#### Implementation pointers in Keras
- Vision Transformers (ViT) in Keras, **but for 2d only**:
    - https://keras.io/examples/vision/image_classification_with_vision_transformer/
- 3D Vision Transformers in Keras, **but for video**:
    - https://keras.io/examples/vision/vivit/
#### Related Issues and Feature Request
- https://neuroinformatics.dev/get-involved/gsoc/projects_2025/brainglobe.html
- https://github.com/brainglobe/cellfinder/issues/267
- https://github.com/brainglobe/cellfinder/issues/301
- https://github.com/brainglobe/cellfinder/issues/298

## How has this PR been tested?

Tested only on sample tiny dataset - for full-scale testing I need an access to a machine with GPU. Please let me know if you can help me with this.

## Is this a breaking change?

This is based on Keras abstractions, and is fully compatible with current classifiers.

## Visualization (the smaller - 4-layer ViT)
<img src="https://github.com/user-attachments/assets/71a3b55a-b273-46e3-b85d-e2e418e80f26" width="500">


BTW, the code used for visualization:
```
import keras
from cellfinder.core.classify.tools import get_model

model = get_model(network_depth="vit-4-layer")
keras.utils.plot_model(
    model,
    show_shapes=True,
    show_dtype=True,
    show_layer_names=True,
    expand_nested=True,
    dpi=50,
    show_layer_activations=True,
)
```
