### PR TITLE
Fix for deleted layers hanging around in CurationWidget

### DIFF
--- a/cellfinder/napari/curation.py
+++ b/cellfinder/napari/curation.py
@@ -94,21 +94,21 @@ class CurationWidget(QWidget):
             self._update_combobox_options(
                 self.training_data_non_cell_choice, self.point_layer_names
             )
-        
+
         @self.viewer.layers.events.removed.connect
         def _remove_selection_layers(event: QtCore.QEvent):
             """
-            Set internal background, signal, training data cell, 
-            and training data non-cell layers to None when they 
+            Set internal background, signal, training data cell,
+            and training data non-cell layers to None when they
             are removed from the napari viewer GUI.
             """
-            if event.value == self.signal_layer: 
+            if event.value == self.signal_layer:
                 self.signal_layer = None
             if event.value == self.background_layer:
                 self.background_layer = None
-            if event.value == self.training_data_cell_layer: 
+            if event.value == self.training_data_cell_layer:
                 self.training_data_cell_layer = None
-            if event.value == self.training_data_non_cell_layer: 
+            if event.value == self.training_data_non_cell_layer:
                 self.training_data_non_cell_layer = None
 
     @staticmethod

--- a/cellfinder/napari/curation.py
+++ b/cellfinder/napari/curation.py
@@ -94,6 +94,22 @@ class CurationWidget(QWidget):
             self._update_combobox_options(
                 self.training_data_non_cell_choice, self.point_layer_names
             )
+        
+        @self.viewer.layers.events.removed.connect
+        def _remove_selection_layers(event: QtCore.QEvent):
+            """
+            Set internal background, signal, training data cell, 
+            and training data non-cell layers to None when they 
+            are removed from the napari viewer GUI.
+            """
+            if event.value == self.signal_layer: 
+                self.signal_layer = None
+            if event.value == self.background_layer:
+                self.background_layer = None
+            if event.value == self.training_data_cell_layer: 
+                self.training_data_cell_layer = None
+            if event.value == self.training_data_non_cell_layer: 
+                self.training_data_non_cell_layer = None
 
     @staticmethod
     def _update_combobox_options(combobox: QComboBox, options_list: List[str]):

--- a/cellfinder/napari/curation.py
+++ b/cellfinder/napari/curation.py
@@ -110,6 +110,7 @@ class CurationWidget(QWidget):
                 self.training_data_cell_layer = None
             if event.value == self.training_data_non_cell_layer: 
                 self.training_data_non_cell_layer = None
+
     @staticmethod
     def _update_combobox_options(combobox: QComboBox, options_list: List[str]):
         original_text = combobox.currentText()

--- a/cellfinder/napari/curation.py
+++ b/cellfinder/napari/curation.py
@@ -110,7 +110,6 @@ class CurationWidget(QWidget):
                 self.training_data_cell_layer = None
             if event.value == self.training_data_non_cell_layer: 
                 self.training_data_non_cell_layer = None
-
     @staticmethod
     def _update_combobox_options(combobox: QComboBox, options_list: List[str]):
         original_text = combobox.currentText()

--- a/tests/napari/test_curation.py
+++ b/tests/napari/test_curation.py
@@ -206,8 +206,8 @@ def test_check_layer_removal_sync(valid_curation_widget):
     viewer = valid_curation_widget.viewer
     viewer.layers.select_all()
     viewer.layers.remove_selected()
-    assert valid_curation_widget.signal_layer == None
-    assert valid_curation_widget.background_layer == None
-    assert valid_curation_widget.training_data_cell_layer == None
-    assert valid_curation_widget.training_data_non_cell_layer == None
+    assert valid_curation_widget.signal_layer is None
+    assert valid_curation_widget.background_layer is None
+    assert valid_curation_widget.training_data_cell_layer is None
+    assert valid_curation_widget.training_data_non_cell_layer is None
     

--- a/tests/napari/test_curation.py
+++ b/tests/napari/test_curation.py
@@ -206,8 +206,8 @@ def test_check_layer_removal_sync(valid_curation_widget):
     viewer = valid_curation_widget.viewer
     viewer.layers.select_all()
     viewer.layers.remove_selected()
-    assert valid_curation_widget.signal_layer is None
-    assert valid_curation_widget.background_layer is None
-    assert valid_curation_widget.training_data_cell_layer is None
-    assert valid_curation_widget.training_data_non_cell_layer is None
+    assert valid_curation_widget.signal_layer == None
+    assert valid_curation_widget.background_layer == None
+    assert valid_curation_widget.training_data_cell_layer == None
+    assert valid_curation_widget.training_data_non_cell_layer == None
     

--- a/tests/napari/test_curation.py
+++ b/tests/napari/test_curation.py
@@ -195,3 +195,19 @@ def test_get_output_directory(valid_curation_widget):
         get_directory.return_value = Path.home()
         valid_curation_widget.get_output_directory()
         assert valid_curation_widget.output_directory == Path.home()
+
+
+@pytest.mark.xfail(reason="See discussion in #443", raises=AssertionError)
+def test_check_layer_removal_sync(valid_curation_widget):
+    """
+    Check that removing a layer from the viewer also removes it from the
+    widget.
+    """
+    viewer = valid_curation_widget.viewer
+    viewer.layers.select_all()
+    viewer.layers.remove_selected()
+    assert valid_curation_widget.signal_layer == None
+    assert valid_curation_widget.background_layer == None
+    assert valid_curation_widget.training_data_cell_layer == None
+    assert valid_curation_widget.training_data_non_cell_layer == None
+    

--- a/tests/napari/test_curation.py
+++ b/tests/napari/test_curation.py
@@ -206,7 +206,7 @@ def test_check_layer_removal_sync(valid_curation_widget):
     viewer = valid_curation_widget.viewer
     viewer.layers.select_all()
     viewer.layers.remove_selected()
-    assert valid_curation_widget.signal_layer == None
-    assert valid_curation_widget.background_layer == None
-    assert valid_curation_widget.training_data_cell_layer == None
-    assert valid_curation_widget.training_data_non_cell_layer == None
+    assert valid_curation_widget.signal_layer is None
+    assert valid_curation_widget.background_layer is None
+    assert valid_curation_widget.training_data_cell_layer is None
+    assert valid_curation_widget.training_data_non_cell_layer is None


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

Adds a function to the constructor of curation.py which removes the curation widget's internal layer references (e.g. self.training_data_cell_layer...) if that layer is deleted from the Napari viewer. This prevents the "training data layers already exist, overwrite with empty layers?" popup from occurring in CurationWidget when you delete training data layers from the viewer and then try to create new training data layers from the CurationWidget.

I'm uncertain what other parts of the codebase are affected by this bug, if any, so I'd like to extend functionality to other areas affected by this bug if anyone happens to know what is affected off the top of their head.

**What is this PR**

- [x] Bug fix

**Why is this PR needed?**

Fixes #345 for the CurationWidget.

**What does this PR do?**

Synchronizes layer deletion between the napari viewer and CurationWidget.

## References

#345

## How has this PR been tested?

- Ran pytest without and with inserted code; no change to pytest results.
- Opened curation widget and created signal/background layers from sample data and cell/non-cell layers according to https://brainglobe.info/tutorials/cellfinder-detection.html. Attempted to create training layers, then deleted training layers from viewer, then re-created layers; no "training data layers already exist" popup occurs. Popup still occurs if one or both training layers are present when you attempt to create training layers (as expected).

## Is this a breaking change?

Not breaking.

## Does this PR require an update to the documentation?

No documentation updates seem to be necessary.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
