### PR TITLE
Remove save weights option from training widget

### DIFF
--- a/cellfinder/napari/train/train.py
+++ b/cellfinder/napari/train/train.py
@@ -60,7 +60,6 @@ def training_widget() -> FunctionGui:
         continue_training: bool,
         augment: bool,
         tensorboard: bool,
-        save_weights: bool,
         save_checkpoints: bool,
         save_progress: bool,
         epochs: int,
@@ -96,9 +95,6 @@ def training_widget() -> FunctionGui:
             Augment the training data to improve generalisation
         tensorboard : bool
             Log to output_directory/tensorboard
-        save_weights : bool
-            Only store the model weights, and not the full model
-            Useful to save storage space
         save_checkpoints : bool
             Store the model at intermediate points during training
         save_progress : bool
@@ -133,7 +129,6 @@ def training_widget() -> FunctionGui:
             continue_training,
             augment,
             tensorboard,
-            save_weights,
             save_checkpoints,
             save_progress,
             epochs,

--- a/cellfinder/napari/train/train_containers.py
+++ b/cellfinder/napari/train/train_containers.py
@@ -75,7 +75,6 @@ class OptionalTrainingInputs(InputContainer):
     continue_training: bool = False
     augment: bool = True
     tensorboard: bool = False
-    save_weights: bool = False
     save_checkpoints: bool = True
     save_progress: bool = True
     epochs: int = 100
@@ -98,7 +97,6 @@ class OptionalTrainingInputs(InputContainer):
             continue_training=cls._custom_widget("continue_training"),
             augment=cls._custom_widget("augment"),
             tensorboard=cls._custom_widget("tensorboard"),
-            save_weights=cls._custom_widget("save_weights"),
             save_checkpoints=cls._custom_widget("save_checkpoints"),
             save_progress=cls._custom_widget("save_progress"),
             epochs=cls._custom_widget("epochs"),


### PR DESCRIPTION
Enhancement: #425 
Removed the save_weights option from the Napari training plugin to ensure consistency.

Reason:
The detection plugin requires a full model, and having an option to save only weights caused confusion.

What was done:
- Removed all save_weights references from the Napari training plugin.
- Now, only full models are saved after training.
- Impact:
- Simplifies usage and ensures compatibility between training and detection.