### PR TITLE
Add progress bar for training widget

### DIFF
--- a/cellfinder/core/train/train_yaml.py
+++ b/cellfinder/core/train/train_yaml.py
@@ -322,10 +322,6 @@ def run(
         Callback,
     )
 
-    from cellfinder.core.classify.cube_generator import CubeGeneratorFromDisk
-    from cellfinder.core.classify.tools import get_model, make_lists
-    from cellfinder.core.tools.prep import prep_model_weights
-
     start_time = datetime.now()
 
     ensure_directory_exists(output_dir)

--- a/cellfinder/core/train/train_yaml.py
+++ b/cellfinder/core/train/train_yaml.py
@@ -316,7 +316,19 @@ def run(
     no_save_checkpoints=False,
     save_progress=False,
     epochs=100,
+    epoch_callback=None,
 ):
+    from keras.callbacks import (
+        Callback,
+        CSVLogger,
+        ModelCheckpoint,
+        TensorBoard,
+    )
+
+    from cellfinder.core.classify.cube_generator import CubeGeneratorFromDisk
+    from cellfinder.core.classify.tools import get_model, make_lists
+    from cellfinder.core.tools.prep import prep_model_weights
+
     start_time = datetime.now()
 
     ensure_directory_exists(output_dir)
@@ -429,6 +441,14 @@ def run(
         csv_filepath = str(output_dir / "training.csv")
         csv_logger = CSVLogger(csv_filepath)
         callbacks.append(csv_logger)
+
+    if epoch_callback is not None:
+
+        class EpochProgressCallback(Callback):
+            def on_epoch_begin(self, epoch, logs=None):
+                epoch_callback(epoch + 1, epochs)
+
+        callbacks.append(EpochProgressCallback())
 
     logger.info("Beginning training.")
     # Keras 3.0: `use_multiprocessing` input is set in the

--- a/cellfinder/core/train/train_yaml.py
+++ b/cellfinder/core/train/train_yaml.py
@@ -320,9 +320,6 @@ def run(
 ):
     from keras.callbacks import (
         Callback,
-        CSVLogger,
-        ModelCheckpoint,
-        TensorBoard,
     )
 
     from cellfinder.core.classify.cube_generator import CubeGeneratorFromDisk

--- a/cellfinder/napari/train/train.py
+++ b/cellfinder/napari/train/train.py
@@ -203,7 +203,7 @@ def training_widget() -> FunctionGui:
             )
             worker.connect_progress_bar_callback(progress_bar)
             worker.finished.connect(
-                lambda: setattr(progress_bar, "visible", False)
+                progress_bar.hide
             )
             worker.errored.connect(
                 lambda e: show_info(f"Error during training: {str(e)}")

--- a/cellfinder/napari/train/train.py
+++ b/cellfinder/napari/train/train.py
@@ -202,6 +202,9 @@ def training_widget() -> FunctionGui:
                 misc_training_inputs,
             )
             worker.connect_progress_bar_callback(progress_bar)
+            worker.finished.connect(
+                lambda: setattr(progress_bar, "visible", False)
+            )
             worker.errored.connect(
                 lambda e: show_info(f"Error during training: {str(e)}")
             )

--- a/cellfinder/napari/train/train.py
+++ b/cellfinder/napari/train/train.py
@@ -2,9 +2,10 @@ from pathlib import Path
 from typing import Optional
 
 from magicgui import magicgui
-from magicgui.widgets import FunctionGui, PushButton
-from napari.qt.threading import thread_worker
+from magicgui.widgets import FunctionGui, ProgressBar, PushButton
+from napari.qt.threading import WorkerBase, WorkerBaseSignals
 from napari.utils.notifications import show_info
+from qtpy.QtCore import Signal
 from qtpy.QtWidgets import QScrollArea
 
 from cellfinder.core.train.train_yaml import run as train_yaml
@@ -18,24 +19,67 @@ from .train_containers import (
 )
 
 
-@thread_worker
-def run_training(
-    training_data_inputs: TrainingDataInputs,
-    optional_network_inputs: OptionalNetworkInputs,
-    optional_training_inputs: OptionalTrainingInputs,
-    misc_training_inputs: MiscTrainingInputs,
-):
-    show_info("Running training...")
-    train_yaml(
-        **training_data_inputs.as_core_arguments(),
-        **optional_network_inputs.as_core_arguments(),
-        **optional_training_inputs.as_core_arguments(),
-        **misc_training_inputs.as_core_arguments(),
-    )
-    show_info("Training finished!")
+class MyWorkerSignals(WorkerBaseSignals):
+    """
+    Signals used by the Worker class (label, max, value).
+    """
+
+    update_progress = Signal(str, int, int)
+
+
+class TrainingWorker(WorkerBase):
+    """
+    Worker that runs training in a separate thread and updates progress bar.
+    """
+
+    def __init__(
+        self,
+        training_data_inputs: TrainingDataInputs,
+        optional_network_inputs: OptionalNetworkInputs,
+        optional_training_inputs: OptionalTrainingInputs,
+        misc_training_inputs: MiscTrainingInputs,
+    ):
+        super().__init__(SignalsClass=MyWorkerSignals)
+        self.training_data_inputs = training_data_inputs
+        self.optional_network_inputs = optional_network_inputs
+        self.optional_training_inputs = optional_training_inputs
+        self.misc_training_inputs = misc_training_inputs
+
+    def connect_progress_bar_callback(self, progress_bar: ProgressBar):
+        """Connects the progress bar to the worker."""
+
+        def update_progress_bar(label: str, max: int, value: int):
+            progress_bar.label = label
+            progress_bar.max = max
+            progress_bar.value = value
+
+        self.signals.update_progress.connect(update_progress_bar)
+
+    def work(self) -> None:
+        """Execute the training with progress updates."""
+        self.signals.update_progress.emit("Starting training...", 1, 0)
+
+        # callbacks for training progress
+        def epoch_callback(epoch: int, total_epochs: int):
+            self.signals.update_progress.emit(
+                f"Training epoch {epoch}/{total_epochs}", total_epochs, epoch
+            )
+
+        # Run the training with the callback
+        train_yaml(
+            **self.training_data_inputs.as_core_arguments(),
+            **self.optional_network_inputs.as_core_arguments(),
+            **self.optional_training_inputs.as_core_arguments(),
+            **self.misc_training_inputs.as_core_arguments(),
+            epoch_callback=epoch_callback,
+        )
+
+        self.signals.update_progress.emit("Training complete", 1, 1)
 
 
 def training_widget() -> FunctionGui:
+    progress_bar = ProgressBar()
+
     @magicgui(
         training_label=html_label_widget("Network training", tag="h3"),
         **TrainingDataInputs.widget_representation(),
@@ -142,12 +186,15 @@ def training_widget() -> FunctionGui:
         if yaml_files[0] == Path.home():  # type: ignore
             show_info("Please select a YAML file for training")
         else:
-            show_info("Starting training process...")
-            worker = run_training(
+            worker = TrainingWorker(
                 training_data_inputs,
                 optional_network_inputs,
                 optional_training_inputs,
                 misc_training_inputs,
+            )
+            worker.connect_progress_bar_callback(progress_bar)
+            worker.errored.connect(
+                lambda e: show_info(f"Error during training: {str(e)}")
             )
             worker.start()
 
@@ -169,5 +216,6 @@ def training_widget() -> FunctionGui:
     scroll = QScrollArea()
     scroll.setWidget(widget._widget._qwidget)
     widget._widget._qwidget = scroll
+    widget.insert(widget.index("number_of_free_cpus") + 1, progress_bar)
 
     return widget

--- a/cellfinder/napari/train/train.py
+++ b/cellfinder/napari/train/train.py
@@ -19,7 +19,7 @@ from .train_containers import (
 )
 
 
-class MyWorkerSignals(WorkerBaseSignals):
+class TrainingWorkerSignals(WorkerBaseSignals):
     """
     Signals used by the Worker class (label, max, value).
     """

--- a/cellfinder/napari/train/train.py
+++ b/cellfinder/napari/train/train.py
@@ -49,6 +49,7 @@ class TrainingWorker(WorkerBase):
         """Connects the progress bar to the worker."""
 
         def update_progress_bar(label: str, max: int, value: int):
+            progress_bar.visible = True
             progress_bar.label = label
             progress_bar.max = max
             progress_bar.value = value
@@ -61,8 +62,11 @@ class TrainingWorker(WorkerBase):
 
         # callbacks for training progress
         def epoch_callback(epoch: int, total_epochs: int):
+            completed_epochs = epoch - 1
             self.signals.update_progress.emit(
-                f"Training epoch {epoch}/{total_epochs}", total_epochs, epoch
+                f"Training epoch {epoch}/{total_epochs}",
+                total_epochs,
+                completed_epochs,
             )
 
         # Run the training with the callback
@@ -78,7 +82,7 @@ class TrainingWorker(WorkerBase):
 
 
 def training_widget() -> FunctionGui:
-    progress_bar = ProgressBar()
+    progress_bar = ProgressBar(visible=False)
 
     @magicgui(
         training_label=html_label_widget("Network training", tag="h3"),
@@ -186,6 +190,11 @@ def training_widget() -> FunctionGui:
         if yaml_files[0] == Path.home():  # type: ignore
             show_info("Please select a YAML file for training")
         else:
+            progress_bar.visible = True
+            progress_bar.label = "Initializing training..."
+            progress_bar.max = 1
+            progress_bar.value = 0
+
             worker = TrainingWorker(
                 training_data_inputs,
                 optional_network_inputs,
@@ -216,6 +225,6 @@ def training_widget() -> FunctionGui:
     scroll = QScrollArea()
     scroll.setWidget(widget._widget._qwidget)
     widget._widget._qwidget = scroll
-    widget.insert(widget.index("number_of_free_cpus") + 1, progress_bar)
+    widget.insert(len(widget) - 1, progress_bar)
 
     return widget

--- a/cellfinder/napari/train/train.py
+++ b/cellfinder/napari/train/train.py
@@ -202,9 +202,7 @@ def training_widget() -> FunctionGui:
                 misc_training_inputs,
             )
             worker.connect_progress_bar_callback(progress_bar)
-            worker.finished.connect(
-                progress_bar.hide
-            )
+            worker.finished.connect(progress_bar.hide)
             worker.errored.connect(
                 lambda e: show_info(f"Error during training: {str(e)}")
             )

--- a/cellfinder/napari/train/train.py
+++ b/cellfinder/napari/train/train.py
@@ -39,7 +39,7 @@ class TrainingWorker(WorkerBase):
         optional_training_inputs: OptionalTrainingInputs,
         misc_training_inputs: MiscTrainingInputs,
     ):
-        super().__init__(SignalsClass=MyWorkerSignals)
+        super().__init__(SignalsClass=TrainingWorkerSignals)
         self.training_data_inputs = training_data_inputs
         self.optional_network_inputs = optional_network_inputs
         self.optional_training_inputs = optional_training_inputs

--- a/tests/napari/test_training.py
+++ b/tests/napari/test_training.py
@@ -64,7 +64,10 @@ def test_run_with_virtual_yaml_files(get_training_widget):
     """
     Checks that training is run with expected set of parameters.
     """
-    with patch("cellfinder.napari.train.train.run_training") as run_training:
+    with patch(
+        "cellfinder.napari.train.train.TrainingWorker"
+    ) as mock_training_worker:
+        mock_worker_instance = mock_training_worker.return_value
         # make default input valid - need yaml files (they don't technically
         # have to exist)
         virtual_yaml_files = (
@@ -86,9 +89,11 @@ def test_run_with_virtual_yaml_files(get_training_widget):
         expected_network_args.trained_model = None
         expected_network_args.model_weights = None
 
-        run_training.assert_called_once_with(
+        mock_training_worker.assert_called_once_with(
             expected_training_args,
             expected_network_args,
             expected_optional_training_args,
             expected_misc_args,
         )
+
+        mock_worker_instance.start.assert_called_once()

--- a/tests/napari/test_training.py
+++ b/tests/napari/test_training.py
@@ -184,6 +184,7 @@ def test_training_worker_execution(mock_train_yaml, training_worker_inputs):
 
     callback = mock_train_yaml.call_args.kwargs["epoch_callback"]
     callback(3, 5)
+    # epoch 3 means 2 completed epochs
     worker.signals.update_progress.emit.assert_any_call(
-        "Training epoch 3/5", 5, 3
+        "Training epoch 3/5", 5, 2
     )


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

This PR Closes #342 by adding progress bar functionality to the neural network training process. Progress bars were previously implemented for detection and curation, but training was missing this feature.

**What does this PR do?**

Adds a progress bar to the training widget in the napari plugin, which updates during each epoch of the neural network training. This gives users visual feedback on training progress.

## References

Implements feature requested in issue #342.
Related to previous PRs that added progress bars for detection ([#73](https://github.com/brainglobe/cellfinder-napari/pull/73)) and curation ([#103](https://github.com/brainglobe/cellfinder-napari/pull/103)).

## How has this PR been tested?

I've tested this functionality by:
1. Running the training widget with sample training data
2. Verifying that the progress bar displays correctly and updates with each epoch
3. Confirming that training completes successfully with the new callback mechanism

## Is this a breaking change?

No, this is a purely additive feature that doesn't change existing behavior.

## Does this PR require an update to the documentation?

No documentation updates are needed as this is a UI enhancement that doesn't change how users interact with the software.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)

<details>
<summary>Screenshot: Progress Bar During Training</summary>

![image](https://github.com/user-attachments/assets/e441a05a-5b57-4d85-8c8e-f0a9aaa498f3)

</details>
