### PR TITLE
Expose CPU/GPU selection in Napari (default to GPU), remove use_scipy param (always True on CPU), and improve batch_size docstring (#464)

### DIFF
--- a/cellfinder/core/detect/detect.py
+++ b/cellfinder/core/detect/detect.py
@@ -49,7 +49,6 @@ def main(
     plane_directory: Optional[str] = None,
     batch_size: Optional[int] = None,
     torch_device: Optional[str] = None,
-    use_scipy: bool = True,
     split_ball_xy_size: int = 3,
     split_ball_z_size: int = 3,
     split_ball_overlap_fraction: float = 0.8,

--- a/cellfinder/core/detect/detect.py
+++ b/cellfinder/core/detect/detect.py
@@ -48,7 +48,7 @@ def main(
     save_planes: bool = False,
     plane_directory: Optional[str] = None,
     batch_size: Optional[int] = None,
-    torch_device: str = "cpu",
+    torch_device: Optional[str] = None,
     use_scipy: bool = True,
     split_ball_xy_size: int = 3,
     split_ball_z_size: int = 3,
@@ -121,9 +121,9 @@ def main(
         becomes slower.
 
     torch_device : str, optional
-        The device on which to run the computation. By default, it's "cpu".
-        To run on a gpu, specify the PyTorch device name, such as "cuda" to
-        run on the first GPU.
+        The device on which to run the computation. If not specified (None),
+        "cuda" will be used if a GPU is available, otherwise "cpu".
+        You can also manually specify "cuda" or "cpu".
 
     callback : Callable[int], optional
         A callback function that is called every time a plane has finished
@@ -135,6 +135,8 @@ def main(
         List of detected cells.
     """
     start_time = datetime.now()
+    if torch_device is None:
+        torch_device = "cuda" if torch.cuda.is_available() else "cpu"
     if batch_size is None:
         if torch_device == "cpu":
             batch_size = 4

--- a/cellfinder/core/detect/detect.py
+++ b/cellfinder/core/detect/detect.py
@@ -155,6 +155,12 @@ def main(
     end_plane = min(len(signal_array), end_plane)
 
     torch_device = torch_device.lower()
+    # Use SciPy filtering on CPU (better performance); use PyTorch on GPU
+    if torch_device != "cuda":
+        use_scipy = True
+    else:
+        use_scipy = False
+
     batch_size = max(batch_size, 1)
     # brainmapper can pass them in as str
     voxel_sizes = list(map(float, voxel_sizes))

--- a/cellfinder/core/main.py
+++ b/cellfinder/core/main.py
@@ -56,8 +56,8 @@ def main(
     detect_finished_callback : Callable[list], optional
         Called after detection is finished with the list of detected points.
         Number of points processed simultaneously by the neural network.
-    batch_size: int = 64, optional   
-        Larger batch sizes use more memory, but can significantly improve 
+    batch_size: int = 64, optional
+        Larger batch sizes use more memory, but can significantly improve
         processing speed when using a GPU.
         Default: 64
     """

--- a/cellfinder/core/main.py
+++ b/cellfinder/core/main.py
@@ -55,6 +55,11 @@ def main(
         Called with the batch number that has just finished.
     detect_finished_callback : Callable[list], optional
         Called after detection is finished with the list of detected points.
+        Number of points processed simultaneously by the neural network.
+    batch_size: int = 64, optional   
+        Larger batch sizes use more memory, but can significantly improve 
+        processing speed when using a GPU.
+        Default: 64
     """
     from cellfinder.core.classify import classify
     from cellfinder.core.detect import detect

--- a/cellfinder/core/main.py
+++ b/cellfinder/core/main.py
@@ -42,6 +42,7 @@ def main(
     detect_callback: Optional[Callable[[int], None]] = None,
     classify_callback: Optional[Callable[[int], None]] = None,
     detect_finished_callback: Optional[Callable[[list], None]] = None,
+    detection_torch_device: Optional[str] = None,
 ) -> List[Cell]:
     """
     Parameters
@@ -77,7 +78,7 @@ def main(
             log_sigma_size,
             n_sds_above_mean_thresh,
             batch_size=classification_batch_size,
-            torch_device=classification_torch_device,
+            torch_device=detection_torch_device,
             callback=detect_callback,
         )
 

--- a/cellfinder/core/main.py
+++ b/cellfinder/core/main.py
@@ -37,12 +37,11 @@ def main(
     skip_classification: bool = False,
     detected_cells: List[Cell] = None,
     classification_batch_size: Optional[int] = None,
-    classification_torch_device: str = "cpu",
+    torch_device: Optional[str] = None,
     *,
     detect_callback: Optional[Callable[[int], None]] = None,
     classify_callback: Optional[Callable[[int], None]] = None,
     detect_finished_callback: Optional[Callable[[list], None]] = None,
-    detection_torch_device: Optional[str] = None,
 ) -> List[Cell]:
     """
     Parameters
@@ -55,11 +54,6 @@ def main(
         Called with the batch number that has just finished.
     detect_finished_callback : Callable[list], optional
         Called after detection is finished with the list of detected points.
-        Number of points processed simultaneously by the neural network.
-    batch_size: int = 64, optional
-        Larger batch sizes use more memory, but can significantly improve
-        processing speed when using a GPU.
-        Default: 64
     """
     from cellfinder.core.classify import classify
     from cellfinder.core.detect import detect
@@ -83,7 +77,7 @@ def main(
             log_sigma_size,
             n_sds_above_mean_thresh,
             batch_size=classification_batch_size,
-            torch_device=detection_torch_device,
+            torch_device=torch_device,
             callback=detect_callback,
         )
 

--- a/cellfinder/napari/detect/detect.py
+++ b/cellfinder/napari/detect/detect.py
@@ -392,7 +392,7 @@ def detect_widget() -> FunctionGui:
             end_plane = len(signal_image.data)
 
         misc_inputs = MiscInputs(
-            start_plane, end_plane, n_free_cpus, analyse_local, debug
+            start_plane, end_plane, n_free_cpus, analyse_local, use_gpu, debug
         )
 
         worker = Worker(

--- a/cellfinder/napari/detect/detect.py
+++ b/cellfinder/napari/detect/detect.py
@@ -261,9 +261,9 @@ def detect_widget() -> FunctionGui:
         end_plane: int,
         n_free_cpus: int,
         analyse_local: bool,
+        use_gpu: bool,
         debug: bool,
         reset_button,
-        detection_torch_device: str,
     ) -> None:
         """
         Run detection and classification.
@@ -316,15 +316,12 @@ def detect_widget() -> FunctionGui:
             How many CPU cores to leave free
         analyse_local : bool
             Only analyse planes around the current position
+        use_gpu : bool
+            If True, use GPU for processing (if available); otherwise, use CPU.
         debug : bool
             Increase logging
         reset_button :
             Reset parameters to default
-        detection_torch_device : str
-            Processing device to use for detection filters
-            Select "cuda" for GPU or "cpu" for CPU.
-            GPU is recommended if available.
-
         """
         # we must manually call so that the parameters of these functions are
         # initialized and updated. Because, if the images are open in napari

--- a/cellfinder/napari/detect/detect.py
+++ b/cellfinder/napari/detect/detect.py
@@ -3,7 +3,6 @@ from math import ceil
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional, Tuple
 
-
 import napari
 import napari.layers
 from brainglobe_utils.cells.cells import Cell

--- a/cellfinder/napari/detect/detect.py
+++ b/cellfinder/napari/detect/detect.py
@@ -321,8 +321,10 @@ def detect_widget() -> FunctionGui:
         reset_button :
             Reset parameters to default
         detection_torch_device : str
-            Processing device to use for detection filters (e.g., morphological filters).
-            Select "cuda" for GPU or "cpu" for CPU. GPU is recommended if available.
+            Processing device to use for detection filters
+            Select "cuda" for GPU or "cpu" for CPU.
+            GPU is recommended if available.
+
         """
         # we must manually call so that the parameters of these functions are
         # initialized and updated. Because, if the images are open in napari

--- a/cellfinder/napari/detect/detect.py
+++ b/cellfinder/napari/detect/detect.py
@@ -3,7 +3,7 @@ from math import ceil
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional, Tuple
 
-import torch
+
 import napari
 import napari.layers
 from brainglobe_utils.cells.cells import Cell
@@ -235,7 +235,6 @@ def detect_widget() -> FunctionGui:
         persist=True,
         reset_button=dict(widget_type="PushButton", text="Reset defaults"),
         scrollable=True,
-        detection_torch_device=dict(widget_type="ComboBox",choices=["cuda", "cpu"],label="Detection Device",value="cuda" if torch.cuda.is_available() else "cpu",tooltip="Device for detection (image processing filters)."),
     )
     def widget(
         detection_label,

--- a/cellfinder/napari/detect/detect.py
+++ b/cellfinder/napari/detect/detect.py
@@ -3,6 +3,7 @@ from math import ceil
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional, Tuple
 
+import torch
 import napari
 import napari.layers
 from brainglobe_utils.cells.cells import Cell
@@ -234,6 +235,7 @@ def detect_widget() -> FunctionGui:
         persist=True,
         reset_button=dict(widget_type="PushButton", text="Reset defaults"),
         scrollable=True,
+        detection_torch_device=dict(widget_type="ComboBox",choices=["cuda", "cpu"],label="Detection Device",value="cuda" if torch.cuda.is_available() else "cpu",tooltip="Device for detection (image processing filters)."),
     )
     def widget(
         detection_label,
@@ -263,6 +265,7 @@ def detect_widget() -> FunctionGui:
         analyse_local: bool,
         debug: bool,
         reset_button,
+        detection_torch_device: str,
     ) -> None:
         """
         Run detection and classification.
@@ -319,6 +322,9 @@ def detect_widget() -> FunctionGui:
             Increase logging
         reset_button :
             Reset parameters to default
+        detection_torch_device : str
+            Processing device to use for detection filters (e.g., morphological filters).
+            Select "cuda" for GPU or "cpu" for CPU. GPU is recommended if available.
         """
         # we must manually call so that the parameters of these functions are
         # initialized and updated. Because, if the images are open in napari

--- a/cellfinder/napari/detect/detect_containers.py
+++ b/cellfinder/napari/detect/detect_containers.py
@@ -2,8 +2,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional
 
-import torch
 import numpy
+import torch
 from brainglobe_utils.cells.cells import Cell
 
 from cellfinder.napari.input_container import InputContainer
@@ -76,8 +76,12 @@ class DetectionInputs(InputContainer):
     def as_core_arguments(self) -> dict:
         detection_input_dict = super().as_core_arguments()
         if self.detection_torch_device is None:
-            self.detection_torch_device = "cuda" if torch.cuda.is_available() else "cpu"
-        detection_input_dict["detection_torch_device"] = self.detection_torch_device
+            self.detection_torch_device = (
+                "cuda" if torch.cuda.is_available() else "cpu"
+            )
+        detection_input_dict["detection_torch_device"] = (
+            self.detection_torch_device
+        )
         return detection_input_dict
 
     @classmethod
@@ -110,7 +114,6 @@ class DetectionInputs(InputContainer):
                 min=0,
                 max=10000000,
             ),
-            
         )
 
 

--- a/cellfinder/napari/detect/detect_containers.py
+++ b/cellfinder/napari/detect/detect_containers.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional
 
+import torch
 import numpy
 from brainglobe_utils.cells.cells import Cell
 
@@ -145,9 +146,13 @@ class MiscInputs(InputContainer):
     n_free_cpus: int = 2
     analyse_local: bool = False
     debug: bool = False
+    detection_torch_device: Optional[str] = None
 
     def as_core_arguments(self) -> dict:
         misc_input_dict = super().as_core_arguments()
+        if self.detection_torch_device is None:
+            self.detection_torch_device = "cuda" if torch.cuda.is_available() else "cpu"
+        misc_input_dict["detection_torch_device"] = self.detection_torch_device
         del misc_input_dict["debug"]
         del misc_input_dict["analyse_local"]
         return misc_input_dict

--- a/cellfinder/napari/detect/detect_containers.py
+++ b/cellfinder/napari/detect/detect_containers.py
@@ -71,9 +71,14 @@ class DetectionInputs(InputContainer):
     n_sds_above_mean_thresh: int = 10
     soma_spread_factor: float = 1.4
     max_cluster_size: int = 100000
+    detection_torch_device: Optional[str] = None
 
     def as_core_arguments(self) -> dict:
-        return super().as_core_arguments()
+        detection_input_dict = super().as_core_arguments()
+        if self.detection_torch_device is None:
+            self.detection_torch_device = "cuda" if torch.cuda.is_available() else "cpu"
+        detection_input_dict["detection_torch_device"] = self.detection_torch_device
+        return detection_input_dict
 
     @classmethod
     def widget_representation(cls) -> dict:
@@ -105,6 +110,7 @@ class DetectionInputs(InputContainer):
                 min=0,
                 max=10000000,
             ),
+            
         )
 
 
@@ -146,13 +152,9 @@ class MiscInputs(InputContainer):
     n_free_cpus: int = 2
     analyse_local: bool = False
     debug: bool = False
-    detection_torch_device: Optional[str] = None
 
     def as_core_arguments(self) -> dict:
         misc_input_dict = super().as_core_arguments()
-        if self.detection_torch_device is None:
-            self.detection_torch_device = "cuda" if torch.cuda.is_available() else "cpu"
-        misc_input_dict["detection_torch_device"] = self.detection_torch_device
         del misc_input_dict["debug"]
         del misc_input_dict["analyse_local"]
         return misc_input_dict

--- a/cellfinder/napari/detect/thread_worker.py
+++ b/cellfinder/napari/detect/thread_worker.py
@@ -41,6 +41,7 @@ class Worker(WorkerBase):
         self.detection_inputs = detection_inputs
         self.classification_inputs = classification_inputs
         self.misc_inputs = misc_inputs
+        
 
     def connect_progress_bar_callback(self, progress_bar: ProgressBar):
         """
@@ -84,6 +85,7 @@ class Worker(WorkerBase):
             **self.detection_inputs.as_core_arguments(),
             **self.classification_inputs.as_core_arguments(),
             **self.misc_inputs.as_core_arguments(),
+            # torch_device is now included inside MiscInputs and passed via as_core_arguments()
             detect_callback=detect_callback,
             classify_callback=classify_callback,
             detect_finished_callback=detect_finished_callback,

--- a/cellfinder/napari/detect/thread_worker.py
+++ b/cellfinder/napari/detect/thread_worker.py
@@ -41,7 +41,6 @@ class Worker(WorkerBase):
         self.detection_inputs = detection_inputs
         self.classification_inputs = classification_inputs
         self.misc_inputs = misc_inputs
-        
 
     def connect_progress_bar_callback(self, progress_bar: ProgressBar):
         """

--- a/cellfinder/napari/detect/thread_worker.py
+++ b/cellfinder/napari/detect/thread_worker.py
@@ -85,7 +85,6 @@ class Worker(WorkerBase):
             **self.detection_inputs.as_core_arguments(),
             **self.classification_inputs.as_core_arguments(),
             **self.misc_inputs.as_core_arguments(),
-            # torch_device is now included inside MiscInputs and passed via as_core_arguments()
             detect_callback=detect_callback,
             classify_callback=classify_callback,
             detect_finished_callback=detect_finished_callback,

--- a/tests/core/test_integration/test_detection.py
+++ b/tests/core/test_integration/test_detection.py
@@ -215,18 +215,15 @@ def test_signal_data_types(synthetic_single_spot, no_free_cpus, dtype, device):
         voxel_sizes=voxel_sizes,
         n_free_cpus=no_free_cpus,
         skip_classification=True,
-        classification_torch_device=device,
+        torch_device=device,
     )
 
     assert len(detected) == 1
     assert detected[0] == Cell(center, Cell.UNKNOWN)
 
 
-@pytest.mark.parametrize("use_scipy", [True, False])
 @pytest.mark.parametrize("device", ["cuda", "cpu"])
-def test_detection_scipy_torch(
-    synthetic_single_spot, no_free_cpus, use_scipy, device
-):
+def test_detection_scipy_torch(synthetic_single_spot, no_free_cpus, device):
 
     if device == "cuda" and not torch.cuda.is_available():
         pytest.xfail("Cuda is not available")
@@ -240,7 +237,6 @@ def test_detection_scipy_torch(
         voxel_sizes=voxel_sizes,
         n_free_cpus=no_free_cpus,
         torch_device=device,
-        use_scipy=use_scipy,
     )
 
     assert len(detected) == 1


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [X] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
To expose GPU/CPU selection and batch size control in the Napari plugin, and to improve usability and performance by automatically handling the `use_scipy` setting depending on the selected device.

**What does this PR do?**
I added device selection (CPU/GPU) in the Napari plugin, defaulting to GPU if available (currently only handling "cuda").

I added some docstrings related to `batch_size`. The `batch_size` parameter was already exposed in the Napari plugin for classification.

The `use_scipy` parameter is now handled automatically: if `torch_device` is "cpu", it’s set to `True`; otherwise, `False`. It is no longer exposed in any interface, as requested.

Notes
In `cellfinder/core/main.py`, the parameter passed to the detection step (`detect`) is the one named `classification_batch_size`, while the `batch_size` parameter is used during the classification stage.

The CLI has not been modified, as it lives in the `brainglobe-workflows` repository.

Device selection currently supports `"cuda"` only. Support for other backends like `"mps"` can be added in a future update if needed.


## References

Please reference any existing issues/PRs that relate to this PR.
Issue #464

## How has this PR been tested?

All changes have been tested locally by running the test suite provided in the repository using `pytest`. All tests pass successfully. I also executed all pre-commit hooks (ruff, black, etc.) which report no issues. Additionally, SonarCloud analysis confirms that our changes meet the Quality Gate requirements. I’ll also attach a few screenshots from the tests.


## Is this a breaking change?

No, this PR does not break any existing functionality. All changes are backward-compatible.


## Does this PR require an update to the documentation?
No, only internal docstrings were updated.


## Checklist:

- [X] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [X] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)

