### PR TITLE
DOCS: Add quick start section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ There are three different ways to interact and use it, each with different user 
 For more details, head over to [the documentation website](https://brainglobe.info/documentation/cellfinder/index.html).
 
 At a glance:
+## Quick Start
+```bash
+# Install with GUI support
+pip install "cellfinder[napari]>=1.0.0"
+
+# Run on sample data
+cellfinder -h
 
 - There is a command-line interface called [brainmapper](https://brainglobe.info/documentation/brainglobe-workflows/brainmapper/index.html) that integrates [with `brainreg`](https://github.com/brainglobe/brainreg) for automated cell detection and classification. You can install it through [`brainglobe-workflows`](https://brainglobe.info/documentation/brainglobe-workflows/index.html).
 - There is a [napari plugin](https://brainglobe.info/documentation/cellfinder/user-guide/napari-plugin/index.html) for interacting graphically with the cellfinder tool.


### PR DESCRIPTION
## Description

**What is this PR**  
- [x] Other (Documentation improvement)  

**Why is this PR needed?**  
- New users often need immediate working examples  
- Reduces onboarding friction (as noted in issue #187 comments)  

**What does this PR do?**  
- Adds minimal "Quick Start" section with:  
  - GUI installation command (`cellfinder[napari]`)  
  - Basic usage example  

## References  
Related to:  
- User feedback in #187 ("steep learning curve")  
- Follows [Diataxis documentation framework](https://diataxis.fr/)  

## How has this PR been tested?  
- Verified commands work in fresh conda env:  
  ```bash
  conda create -n test-env python=3.9
  conda activate test-env
  pip install "cellfinder[napari]>=1.0.0"