### PR TITLE
Update pinned pytorch version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,4 +139,3 @@ mprofile*.dat
 
 .idea/
 .vscode/
-.qodo

--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,4 @@ mprofile*.dat
 
 .idea/
 .vscode/
+.qodo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "scikit-image",
     "scikit-learn",
     "keras>=3.7.0",
-    "torch>=2.1.0,!=2.4",
+    "torch>=2.4.1",
     "tifffile",
     "tqdm",
     "qt-niu"


### PR DESCRIPTION
What is this PR

 Bug fix

<!-- It fixes a known issue with an outdated torch version. -->
Why is this PR needed?

This PR updates the PyTorch version to >=2.4.1, skipping 2.4.0 which contained a bug affecting inference on Windows. The bug has been resolved upstream in PyTorch. See [pytorch/pytorch#131958](https://github.com/pytorch/pytorch/issues/131958) for reference.

What does this PR do?

Updates the pyproject.toml dependency list to require torch>=2.4.1

Ensures Cellfinder avoids the buggy PyTorch 2.4.0 version