### PR TITLE
Fix #468: Implemented search space restrictions in all dimensions (z, y, x) for cell detection

### DIFF
--- a/cellfinder/core/detect/detect.py
+++ b/cellfinder/core/detect/detect.py
@@ -33,6 +33,10 @@ def main(
     signal_array: types.array,
     start_plane: int = 0,
     end_plane: int = -1,
+    start_y: int = 0,
+    end_y: int = -1,
+    start_x: int = 0,
+    end_x: int = -1,
     voxel_sizes: Tuple[float, float, float] = (5, 2, 2),
     soma_diameter: float = 16,
     max_cluster_size: float = 100_000,
@@ -153,6 +157,13 @@ def main(
     if end_plane < 0:
         end_plane = len(signal_array)
     end_plane = min(len(signal_array), end_plane)
+    if end_y < 0:
+        end_y = signal_array.shape[1]
+    end_y = min(signal_array.shape[1], end_y)
+
+    if end_x < 0:
+        end_x = signal_array.shape[2]
+    end_x = min(signal_array.shape[2], end_x)
 
     torch_device = torch_device.lower()
     batch_size = max(batch_size, 1)
@@ -170,6 +181,10 @@ def main(
         ball_z_size_um=ball_z_size,
         start_plane=start_plane,
         end_plane=end_plane,
+        start_y=start_y,
+        end_y=end_y,
+        start_x=start_x,
+        end_x=end_x,
         n_free_cpus=n_free_cpus,
         ball_overlap_fraction=ball_overlap_fraction,
         log_sigma_size=log_sigma_size,

--- a/cellfinder/core/detect/filters/setup_filters.py
+++ b/cellfinder/core/detect/filters/setup_filters.py
@@ -202,12 +202,13 @@ class DetectionSettings:
     n_splitting_iter: int = 10
     """
     During the structure splitting phase we iteratively shrink the bright areas
-    and re-filter with the 3d filter. 
+    and re-filter with the 3d filter.
     This is the number of iterations to do.
 
     This is a maximum because we also stop if there are no more structures left
     during any iteration.
     """
+
     @cached_property
     def roi_shape(self) -> Tuple[int, int]:
         """the shape of the region of interest
@@ -223,6 +224,7 @@ class DetectionSettings:
             else min(self.end_x, self.plane_shape[1])
         )
         return (end_y - self.start_y, end_x - self.start_x)
+
     def __getstate__(self):
         d = self.__dict__.copy()
         # when sending across processes, we need to be able to pickle. This

--- a/cellfinder/core/detect/filters/setup_filters.py
+++ b/cellfinder/core/detect/filters/setup_filters.py
@@ -47,7 +47,19 @@ class DetectionSettings:
 
     Defaults to `uint16`
     """
+    start_y: int = 0
+    """The starting y coordinate for processing (inclusive)."""
 
+    end_y: int = -1
+    """The ending y coordinate for processing (exclusive).
+    -1 means process until the end."""
+
+    start_x: int = 0
+    """The starting x coordinate for processing (inclusive)."""
+
+    end_x: int = -1
+    """The ending x coordinate for processing (exclusive).
+    -1 means process until the end."""
     detection_dtype: Type[np.number] = np.uint64
     """
     The numpy data type that the cell detection code expects our filtered
@@ -190,12 +202,27 @@ class DetectionSettings:
     n_splitting_iter: int = 10
     """
     During the structure splitting phase we iteratively shrink the bright areas
-    and re-filter with the 3d filter. This is the number of iterations to do.
+    and re-filter with the 3d filter. 
+    This is the number of iterations to do.
 
     This is a maximum because we also stop if there are no more structures left
     during any iteration.
     """
-
+    @cached_property
+    def roi_shape(self) -> Tuple[int, int]:
+        """the shape of the region of interest
+        in y and x dimensions."""
+        end_y = (
+            self.plane_shape[0]
+            if self.end_y < 0
+            else min(self.end_y, self.plane_shape[0])
+        )
+        end_x = (
+            self.plane_shape[1]
+            if self.end_x < 0
+            else min(self.end_x, self.plane_shape[1])
+        )
+        return (end_y - self.start_y, end_x - self.start_x)
     def __getstate__(self):
         d = self.__dict__.copy()
         # when sending across processes, we need to be able to pickle. This

--- a/tests/core/test_unit/test_detect/test_filters/test_setup_filters.py
+++ b/tests/core/test_unit/test_detect/test_filters/test_setup_filters.py
@@ -130,22 +130,23 @@ def test_bad_ball_z_size():
         # do something with value to quiet linter
         assert settings.ball_z_size
 
+
 @pytest.mark.parametrize(
     "plane_shape,start_y,end_y,start_x,end_x,expected_shape",
     [
-        #basic case - full plane
+        # basic case - full plane
         ((100, 200), 0, -1, 0, -1, (100, 200)),
-        #partial region with positive coordinates
+        # partial region with positive coordinates
         ((100, 200), 10, 50, 20, 100, (40, 80)),
-        #end coordinates exceeding plane dimensions
+        # end coordinates exceeding plane dimensions
         ((100, 200), 0, 150, 0, 300, (100, 200)),
-        #negative end coordinates (should use full dimension)
+        # negative end coordinates (should use full dimension)
         ((100, 200), 10, -1, 20, -1, (90, 180)),
-        #zero-sized region
+        # zero-sized region
         ((100, 200), 50, 50, 60, 60, (0, 0)),
-        #single pixel region
+        # single pixel region
         ((100, 200), 50, 51, 60, 61, (1, 1)),
-        #minimum plane size
+        # minimum plane size
         ((1, 1), 0, -1, 0, -1, (1, 1)),
     ],
 )
@@ -172,13 +173,13 @@ def test_roi_shape_default_values():
 @pytest.mark.parametrize(
     "plane_shape,start_y,end_y,start_x,end_x",
     [
-        #start coordinate larger than end
+        # start coordinate larger than end
         ((100, 200), 50, 40, 0, -1),
         ((100, 200), 0, -1, 50, 40),
-        #start coordinate negative
+        # start coordinate negative
         ((100, 200), -10, 50, 0, -1),
         ((100, 200), 0, -1, -10, 50),
-        #both coordinates negative
+        # both coordinates negative
         ((100, 200), -10, -5, 0, -1),
         ((100, 200), 0, -1, -10, -5),
     ],
@@ -194,6 +195,6 @@ def test_roi_shape_invalid_coordinates(
         start_x=start_x,
         end_x=end_x,
     )
-    #for invalid coordinates, expect a non-negative region size
+    # for invalid coordinates, expect a non-negative region size
     shape = settings.roi_shape
     assert shape[0] >= 0 and shape[1] >= 0

--- a/tests/core/test_unit/test_detect/test_filters/test_setup_filters.py
+++ b/tests/core/test_unit/test_detect/test_filters/test_setup_filters.py
@@ -129,3 +129,71 @@ def test_bad_ball_z_size():
     with pytest.raises(ValueError):
         # do something with value to quiet linter
         assert settings.ball_z_size
+
+@pytest.mark.parametrize(
+    "plane_shape,start_y,end_y,start_x,end_x,expected_shape",
+    [
+        #basic case - full plane
+        ((100, 200), 0, -1, 0, -1, (100, 200)),
+        #partial region with positive coordinates
+        ((100, 200), 10, 50, 20, 100, (40, 80)),
+        #end coordinates exceeding plane dimensions
+        ((100, 200), 0, 150, 0, 300, (100, 200)),
+        #negative end coordinates (should use full dimension)
+        ((100, 200), 10, -1, 20, -1, (90, 180)),
+        #zero-sized region
+        ((100, 200), 50, 50, 60, 60, (0, 0)),
+        #single pixel region
+        ((100, 200), 50, 51, 60, 61, (1, 1)),
+        #minimum plane size
+        ((1, 1), 0, -1, 0, -1, (1, 1)),
+    ],
+)
+def test_roi_shape(
+    plane_shape, start_y, end_y, start_x, end_x, expected_shape
+):
+    """Test that roi_shape correctly calculates region dimensions."""
+    settings = DetectionSettings(
+        plane_shape=plane_shape,
+        start_y=start_y,
+        end_y=end_y,
+        start_x=start_x,
+        end_x=end_x,
+    )
+    assert settings.roi_shape == expected_shape
+
+
+def test_roi_shape_default_values():
+    """Test roi_shape with default constructor values."""
+    settings = DetectionSettings()
+    assert settings.roi_shape == (1, 1)
+
+
+@pytest.mark.parametrize(
+    "plane_shape,start_y,end_y,start_x,end_x",
+    [
+        #start coordinate larger than end
+        ((100, 200), 50, 40, 0, -1),
+        ((100, 200), 0, -1, 50, 40),
+        #start coordinate negative
+        ((100, 200), -10, 50, 0, -1),
+        ((100, 200), 0, -1, -10, 50),
+        #both coordinates negative
+        ((100, 200), -10, -5, 0, -1),
+        ((100, 200), 0, -1, -10, -5),
+    ],
+)
+def test_roi_shape_invalid_coordinates(
+    plane_shape, start_y, end_y, start_x, end_x
+):
+    """Test that roi_shape handles invalid coordinates appropriately."""
+    settings = DetectionSettings(
+        plane_shape=plane_shape,
+        start_y=start_y,
+        end_y=end_y,
+        start_x=start_x,
+        end_x=end_x,
+    )
+    #for invalid coordinates, expect a non-negative region size
+    shape = settings.roi_shape
+    assert shape[0] >= 0 and shape[1] >= 0


### PR DESCRIPTION
## Description
**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

 - Allows users to restrict the search space in all dimensions using coordinates like (:, 100:400, 200:500) for (z, y, x).
 - The implementation maintains compatibility with both `napari` plugin data and dask-loaded data, ensuring proper handling of boundary conditions and coordinate transformations.
  
**What does this PR do?**

Adds a new feature to run cell detection on a subvolume of an image and not just select z by :-
     1.) Adding new parameters to DetectionSettings class:
              - `start_y`, `end_y`: for restricting the y-dimension search space.
              - `start_x`, `end_x`: for restricting the x-dimension search space.
              - added `roi_shape` property to calculate the shape of the region of interest.
              - updated the main detection function in detect.py.        
    2.) modified DetectionSettings initialization to include these parameters.

## References

- #468 
- #494 
- #491 
- #524 

## How has this PR been tested?

Verified functionality with:
     - Full volume detection (no restrictions) 
     - Partial volume detection in all dimensions
     - Edge cases (coordinates at/outside volume boundaries)

Tested with both:
        - `napari` plugin interface
        - Direct dask array input

## Is this a breaking change?
- No

## Does this PR require an update to the documentation?
- No

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
