### PR TITLE
make check_training_data_exists more strict, and test it

### DIFF
--- a/cellfinder/napari/curation.py
+++ b/cellfinder/napari/curation.py
@@ -496,23 +496,24 @@ class CurationWidget(QWidget):
 
     def check_training_data_exists(self) -> bool:
         if not (
-            self.training_data_cell_layer or self.training_data_non_cell_layer
+            self.training_data_cell_layer and self.training_data_non_cell_layer
         ):
             show_info(
                 "No training data layers have been added. "
-                "Please add a layer and annotate some points.",
+                "Please add layers for both cells and non-cells,"
+                "and annotate some points in both.",
             )
             return False
         else:
             if (
                 len(self.training_data_cell_layer.data) > 0
-                or len(self.training_data_non_cell_layer.data) > 0
+                and len(self.training_data_non_cell_layer.data) > 0
             ):
                 return True
             else:
                 show_info(
                     "No training data points have been added. "
-                    "Please annotate some points.",
+                    "Please annotate points in both training data layers.",
                 )
                 return False
 

--- a/tests/napari/test_curation.py
+++ b/tests/napari/test_curation.py
@@ -210,3 +210,26 @@ def test_check_layer_removal_sync(valid_curation_widget):
     assert valid_curation_widget.background_layer is None
     assert valid_curation_widget.training_data_cell_layer is None
     assert valid_curation_widget.training_data_non_cell_layer is None
+
+
+# @pytest.mark.xfail(reason="See discussion in #443", raises=AssertionError)
+@pytest.mark.parametrize(
+    "layer_indices_to_remove",
+    [[-2], [-3], [-2, -3]],
+    ids=(
+        "users deletes non-cell training data layer",
+        "user deletes cell training data layer",
+        "user deletes both",
+    ),
+)
+def test_training_data_does_not_exist_when_user_removes_layers(
+    valid_curation_widget, layer_indices_to_remove
+):
+    for layer in layer_indices_to_remove:
+        valid_curation_widget.viewer.layers.pop(layer)
+    assert not valid_curation_widget.check_training_data_exists()
+
+
+# @pytest.mark.xfail(reason="See discussion in #443", raises=AssertionError)
+def test_valid_widget_has_valid_training_data(valid_curation_widget):
+    assert valid_curation_widget.check_training_data_exists()


### PR DESCRIPTION
**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**What does this PR do?**

Makes `check_training_data_exists` more strict, by requiring both non-empty training data layers to return True.
Also adds tests and docstring for this function.

## References

Closes #527 

## How has this PR been tested?

I have run new tests locally without the `xfail` and they pass, only after the changes made here to the source code, but not before.

## Is this a breaking change?

Yes - users can't get away with one empty or non-existent training data layer anymore.

## Does this PR require an update to the documentation?

Our tutorial still works the same, so no change needed there. This change enforces good practice with users.
Have added a docstring to a function that didn't have one.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
