### PR TITLE
Don't deepcopy input arrays to prevent loading into RAM

### DIFF
--- a/cellfinder/napari/detect/detect_containers.py
+++ b/cellfinder/napari/detect/detect_containers.py
@@ -30,7 +30,7 @@ class DataInputs(InputContainer):
             self.voxel_size_x,
         )
         # del operator doesn't affect self, because asdict creates a copy of
-        # fields.
+        # the dict.
         del data_input_dict["voxel_size_z"]
         del data_input_dict["voxel_size_y"]
         del data_input_dict["voxel_size_x"]

--- a/cellfinder/napari/input_container.py
+++ b/cellfinder/napari/input_container.py
@@ -1,6 +1,16 @@
 from abc import abstractmethod
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass, fields
 from typing import Optional
+
+
+def asdict_no_copy(obj: dataclass) -> dict:
+    """
+    Similar to `asdict`, except it makes no copies of the field values.
+    asdict will do a deep copy of field values that are non-basic objects.
+
+    It still creates a new dict to return, though.
+    """
+    return {field.name: getattr(obj, field.name) for field in fields(obj)}
 
 
 @dataclass
@@ -23,7 +33,7 @@ class InputContainer:
         # Derived classes are not expected to be particularly
         # slow to instantiate, so use the default constructor
         # to avoid code repetition.
-        return asdict(cls())
+        return asdict_no_copy(cls())
 
     @abstractmethod
     def as_core_arguments(self) -> dict:
@@ -32,10 +42,10 @@ class InputContainer:
         The implementation provided here can be re-used in derived classes, if
         convenient.
         """
-        # note that asdict returns a new instance of a dict,
+        # note that asdict_no_copy returns a new instance of a dict,
         # so any subsequent modifications of this dict won't affect the class
         # instance
-        return asdict(self)
+        return asdict_no_copy(self)
 
     @classmethod
     def _custom_widget(

--- a/tests/napari/test_input_containers.py
+++ b/tests/napari/test_input_containers.py
@@ -1,0 +1,13 @@
+from dataclasses import asdict, dataclass
+
+from cellfinder.napari.input_container import asdict_no_copy
+
+
+def test_asdict_no_copy():
+    @dataclass
+    class Data:
+        a: int = 5
+        b: str = "hello"
+
+    data = Data(a=12, b="bye")
+    assert asdict_no_copy(data) == asdict(data)


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

I noticed while using napari to classify points from a large tiff that had been memmapped, that the tiff would be loaded fully into memory at some point. I traced it down to `asdict` doing a `deepcopy` of all the field values of the data class. Or rather it only does it for non basic object types.

This means that all the data layers inputs get deep copied, even if they are memmaped so that it loads the full data into memory. Which is not wanted.

**What does this PR do?**

With this PR, we use our own version of `asdict` that converts the data class into a dict without doing the `deepcopy`.

## References

Please reference any existing issues/PRs that relate to this PR.

## How has this PR been tested?

I manually tested it in napari and also added a test function.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)


I think it would be a good idea to add an end-to-end test with a large tiff that is opened via memmap (or dask, although I'm not sure deep copying a dask array would load the data into memory) and check that it isn't loaded into memory. But I'm not sure how to do this in a automatic test without creating large files on disk. Otherwise if it's a small test tiff it'd be hard to know if the file is loaded into memory.

Perhaps that needs to stay as manual test?