### PR TITLE
Run scheduled tests on napari main

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -86,6 +86,15 @@ jobs:
           secret-codecov-token: ${{ secrets.CODECOV_TOKEN }}
           use-xvfb: true
 
+      # Run tests on napari main if this is a scheduled run
+      - name: Run tests on napari main
+        if: github.event_name == 'schedule'
+        uses: neuroinformatics-unit/actions/test@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          secret-codecov-token: ${{ secrets.CODECOV_TOKEN }}
+          tox-args: '-e napari-dev'
+
       - name: Notify slack on scheduled failure
         if: failure() && github.event_name == 'schedule'
         uses: ravsamhq/notify-slack-action@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ markers = ["slow: marks tests as slow (deselect with '-m \"not slow\"')"]
 legacy_tox_ini = """
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{311,312,313}
+envlist = py{311,312,313}, napari-dev
 isolated_build = true
 
 [gh-actions]
@@ -139,4 +139,6 @@ passenv =
     NUMPY_EXPERIMENTAL_ARRAY_FUNCTION
     PYVISTA_OFF_SCREEN
     BRAINGLOBE_TEST_DATA_DIR
+deps =
+    napari-dev: git+https://github.com/napari/napari
 """


### PR DESCRIPTION
Adds an extra run of the neuroinformatics/actions/test with napari installed from main. This action will only run during the weekly cron job.