### PR TITLE
Pin napari to >=0.6.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ napari = [
     "magicgui",
     "napari-ndtiffs",
     "napari-plugin-engine >= 0.1.4",
-    "napari[pyqt5]",
+    "napari[pyqt5]>=0.6.1",
     "pooch >= 1",
     "qtpy",
 ]


### PR DESCRIPTION
This PR pins napari to version >=0.6.1.