### PR TITLE
Fix #443 by removing the leaking logs from pytest

### DIFF
--- a/tests/napari/conftest.py
+++ b/tests/napari/conftest.py
@@ -1,0 +1,17 @@
+import pytest
+
+
+@pytest.fixture
+def create_napari_viewer(make_napari_viewer, caplog):
+    """Shim for make_napari_viewer, that cleans up caplog from holding
+    onto widgets. See issue #443.
+    """
+    yield make_napari_viewer
+
+    # we only need to remove the logs if test didn't fail. Napari doesn't
+    # check about memory leaks for failed tests
+    for when in ("setup", "call", "teardown"):
+        records = caplog.get_records(when)
+        indices = [i for i, r in enumerate(records) if r.name == "in_n_out"]
+        for i in indices[::-1]:
+            del records[i]

--- a/tests/napari/test_curation.py
+++ b/tests/napari/test_curation.py
@@ -12,19 +12,19 @@ from cellfinder.napari.sample_data import load_sample
 
 
 @pytest.fixture
-def curation_widget(make_napari_viewer):
+def curation_widget(create_napari_viewer):
     """
     Create a viewer, add the curation widget, and return the widget.
     The viewer can be accessed using ``widget.viewer``.
     """
-    viewer = make_napari_viewer()
+
+    viewer = create_napari_viewer()
     _, widget = viewer.window.add_plugin_dock_widget(
         plugin_name="cellfinder", widget_name="Curation"
     )
     return widget
 
 
-@pytest.mark.xfail(reason="See discussion in #443", raises=AssertionError)
 def test_add_new_training_layers(curation_widget):
     viewer = curation_widget.viewer
     layers = viewer.layers
@@ -39,7 +39,6 @@ def test_add_new_training_layers(curation_widget):
     assert layers[1].name == "Training data (non cells)"
 
 
-@pytest.mark.xfail(reason="See discussion in #443", raises=AssertionError)
 def test_cell_marking(curation_widget, tmp_path):
     """
     Check that marking cells and non-cells works as expected.
@@ -92,13 +91,13 @@ def test_cell_marking(curation_widget, tmp_path):
 
 
 @pytest.fixture
-def valid_curation_widget(make_napari_viewer) -> CurationWidget:
+def valid_curation_widget(create_napari_viewer) -> CurationWidget:
     """
     Setup up a valid curation widget,
     complete with training data layers and points,
     and signal+background images.
     """
-    viewer = make_napari_viewer()
+    viewer = create_napari_viewer()
     image_layers = load_sample()
     for layer in image_layers:
         viewer.add_layer(napari.layers.Image(layer[0], **layer[1]))
@@ -132,7 +131,6 @@ def valid_curation_widget(make_napari_viewer) -> CurationWidget:
     return curation_widget
 
 
-@pytest.mark.xfail(reason="See discussion in #443", raises=AssertionError)
 def test_check_image_data_for_extraction(valid_curation_widget):
     """
     Check valid curation widget has extractable data.
@@ -140,7 +138,6 @@ def test_check_image_data_for_extraction(valid_curation_widget):
     assert valid_curation_widget.check_image_data_for_extraction()
 
 
-@pytest.mark.xfail(reason="See discussion in #443", raises=AssertionError)
 def test_check_image_data_wrong_shape(valid_curation_widget):
     """
     Check curation widget shows expected user message if images don't have
@@ -160,7 +157,6 @@ def test_check_image_data_wrong_shape(valid_curation_widget):
         )
 
 
-@pytest.mark.xfail(reason="See discussion in #443", raises=AssertionError)
 def test_check_image_data_missing_signal(valid_curation_widget):
     """
     Check curation widget shows expected user message if signal image is
@@ -175,14 +171,12 @@ def test_check_image_data_missing_signal(valid_curation_widget):
         )
 
 
-@pytest.mark.xfail(reason="See discussion in #443", raises=AssertionError)
 def test_is_data_extractable(curation_widget, valid_curation_widget):
     """Check is_data_extractable works as expected."""
     assert not curation_widget.is_data_extractable()
     assert valid_curation_widget.is_data_extractable()
 
 
-@pytest.mark.xfail(reason="See discussion in #443", raises=AssertionError)
 def test_get_output_directory(valid_curation_widget):
     """Check get_output_directory returns expected value."""
     with patch(
@@ -197,7 +191,6 @@ def test_get_output_directory(valid_curation_widget):
         assert valid_curation_widget.output_directory == Path.home()
 
 
-@pytest.mark.xfail(reason="See discussion in #443", raises=AssertionError)
 def test_check_layer_removal_sync(valid_curation_widget):
     """
     Check that removing a layer from the viewer also removes it from the

--- a/tests/napari/test_detection.py
+++ b/tests/napari/test_detection.py
@@ -15,8 +15,8 @@ from cellfinder.napari.sample_data import load_sample
 
 
 @pytest.fixture
-def get_detect_widget(make_napari_viewer):
-    viewer = make_napari_viewer()
+def get_detect_widget(create_napari_viewer):
+    viewer = create_napari_viewer()
     widget = detect_widget()
     for layer in load_sample():
         viewer.add_layer(napari.layers.Image(layer[0], **layer[1]))
@@ -43,7 +43,6 @@ def test_detect_worker():
     worker.work()
 
 
-@pytest.mark.xfail(reason="See discussion in #443", raises=AssertionError)
 @pytest.mark.parametrize(
     argnames="analyse_local",
     argvalues=[True, False],  # increase test coverage by covering both cases
@@ -68,7 +67,6 @@ def test_run_detect_without_inputs():
         assert show_info.called
 
 
-@pytest.mark.xfail(reason="See discussion in #443", raises=AssertionError)
 def test_reset_defaults(get_detect_widget):
     """Smoke test that restore defaults doesn't error."""
     get_detect_widget.reset_button.clicked()

--- a/tests/napari/test_training.py
+++ b/tests/napari/test_training.py
@@ -13,8 +13,8 @@ from cellfinder.napari.train.train_containers import (
 
 
 @pytest.fixture
-def get_training_widget(make_napari_viewer):
-    viewer = make_napari_viewer()
+def get_training_widget(create_napari_viewer):
+    viewer = create_napari_viewer()
     widget = training_widget()
     _, widget = viewer.window.add_plugin_dock_widget(
         plugin_name="cellfinder", widget_name="Train network"
@@ -23,7 +23,6 @@ def get_training_widget(make_napari_viewer):
     return widget
 
 
-@pytest.mark.xfail(reason="See discussion in #443", raises=AssertionError)
 def test_reset_to_defaults(get_training_widget):
     """
     A simple test for the reset button.
@@ -46,7 +45,6 @@ def test_reset_to_defaults(get_training_widget):
     assert get_training_widget.test_fraction.value == 0.10
 
 
-@pytest.mark.xfail(reason="See discussion in #443", raises=AssertionError)
 def test_run_with_no_yaml_files(get_training_widget):
     """
     Checks whether expected info message will be shown to user if they don't
@@ -59,7 +57,6 @@ def test_run_with_no_yaml_files(get_training_widget):
         )
 
 
-@pytest.mark.xfail(reason="See discussion in #443", raises=AssertionError)
 def test_run_with_virtual_yaml_files(get_training_widget):
     """
     Checks that training is run with expected set of parameters.

--- a/tests/napari/test_utils.py
+++ b/tests/napari/test_utils.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from brainglobe_utils.cells.cells import Cell
 
 from cellfinder.napari.utils import (
@@ -11,8 +10,7 @@ from cellfinder.napari.utils import (
 )
 
 
-@pytest.mark.xfail(reason="See discussion in #443", raises=AssertionError)
-def test_add_classified_layers(make_napari_viewer):
+def test_add_classified_layers(create_napari_viewer):
     """Smoke test for add_classified_layers utility"""
     cell_pos = [1, 2, 3]
     unknown_pos = [4, 5, 6]
@@ -20,7 +18,7 @@ def test_add_classified_layers(make_napari_viewer):
         Cell(pos=cell_pos, cell_type=Cell.CELL),
         Cell(pos=unknown_pos, cell_type=Cell.UNKNOWN),
     ]
-    viewer = make_napari_viewer()
+    viewer = create_napari_viewer()
     n_layers = len(viewer.layers)
     # adds a "detected" and a "rejected layer"
     add_classified_layers(


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

#443 shows that some logs are leaking objects. Specifically, when fancylog was used during a test, it set the logging level of the default logger to debug without changing it back afterwards. This resulted in all subsequent tests emitting debug logs.

Next, the `in_n_out` library used by `napari` will debug log all napari objects and the pytest `caplog` fixture saves all logs forever. So when napari checks after each test whether there's a memory leak of their widgets, because caplog does leak the widgets, the tests fails.

**What does this PR do?**

This clears these logs from `caplog` after the test, if the test worked, preventing the leaks.

## References

https://github.com/brainglobe/cellfinder/issues/443, https://github.com/napari/napari/issues/8287.

## How has this PR been tested?

Locally.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
