### PR TITLE
Pin minimum fancylog version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "brainglobe-utils>=0.5.0",
     "brainglobe-napari-io>=0.3.4",
     "dask[array]",
-    "fancylog>=0.0.7",
+    "fancylog>=0.6.0",
     "natsort",
     "numba",
     "numpy",


### PR DESCRIPTION
Following #561 I realised we should pin the minimum fancylog version, otherwise just updating cellfinder will cause issues.