### PR TITLE
free-disk space action should run on all ubuntu runners

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -128,7 +128,6 @@ jobs:
     steps:
       # Free up disk space on ubuntu runners
       - name: Free Disk Space
-        if: runner.os == 'ubuntu-latest'
         uses: endersonmenezes/free-disk-space@6c4664f43348c8c7011b53488d5ca65e9fc5cd1a # v3
         with:
           remove_android: true
@@ -185,7 +184,6 @@ jobs:
     steps:
       # Free up disk space on ubuntu runners
       - name: Free Disk Space
-        if: matrix.os == 'ubuntu-latest'
         uses: endersonmenezes/free-disk-space@6c4664f43348c8c7011b53488d5ca65e9fc5cd1a # v3
         with:
           remove_android: true


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**What does this PR do?**

This PR avoids sporadic test failures related to the runner VM's available disk space for the non-standard tests we run for cellfinder (the numba-disabled run and the brainmapper CLI tests).

It does so by removing a conditional on the operating system in the `free-disk-space` step. This simplifies the step (it's only run on one OS anyway, so we don't need to condition on the OS: we either have the step or not) and should avoid sporadic test failures such as https://github.com/brainglobe/cellfinder/actions/runs/20222458182
