### PR TITLE
vectorised binning

### DIFF
--- a/cellfinder/core/tools/array_operations.py
+++ b/cellfinder/core/tools/array_operations.py
@@ -103,11 +103,17 @@ def bin_mean_3d(
             )
         )
 
-    binned_arr = []
-    for i in range(0, arr.shape[2] - 1, bin_depth):
-        sub_stack = [
-            binned_mean_2d(arr[:, :, j], bin_width, bin_height)
-            for j in range(i, i + bin_depth)
-        ]
-        binned_arr.append(np.dstack(sub_stack).mean(axis=2))
-    return np.dstack(binned_arr)
+    width_bins = arr.shape[0] // bin_width
+    height_bins = arr.shape[1] // bin_height
+    depth_bins = arr.shape[2] // bin_depth
+    # all padding check already done above:)
+    arr = np.ascontiguousarray(arr)
+    reshaped = arr.reshape(
+        width_bins,
+        bin_width,
+        height_bins,
+        bin_height,
+        depth_bins,
+        bin_depth,
+    )
+    return reshaped.mean(axis=(1, 3, 5))

--- a/tests/core/test_unit/test_tools/test_array_operations.py
+++ b/tests/core/test_unit/test_tools/test_array_operations.py
@@ -1,0 +1,47 @@
+import numpy as np
+import pytest
+
+from cellfinder.core.tools import array_operations as ops
+
+
+def _bin_mean_3d_reference(
+    arr: np.ndarray, bin_width: int, bin_height: int, bin_depth: int
+) -> np.ndarray:
+    width_bins = arr.shape[0] // bin_width
+    height_bins = arr.shape[1] // bin_height
+    depth_bins = arr.shape[2] // bin_depth
+    out = np.empty((width_bins, height_bins, depth_bins), dtype=np.float64)
+
+    for i in range(width_bins):
+        for j in range(height_bins):
+            for k in range(depth_bins):
+                x0, x1 = i * bin_width, (i + 1) * bin_width
+                y0, y1 = j * bin_height, (j + 1) * bin_height
+                z0, z1 = k * bin_depth, (k + 1) * bin_depth
+                out[i, j, k] = arr[x0:x1, y0:y1, z0:z1].mean()
+
+    return out
+
+
+def test_bin_mean_3d_values_and_shape():
+    arr = np.arange(4 * 6 * 8, dtype=np.float32).reshape(4, 6, 8)
+    result = ops.bin_mean_3d(arr, bin_width=2, bin_height=3, bin_depth=4)
+    expected = _bin_mean_3d_reference(arr, 2, 3, 4)
+
+    assert result.shape == (2, 2, 2)
+    assert np.allclose(result, expected)
+
+
+@pytest.mark.parametrize(
+    "shape,bin_sizes",
+    [
+        ((5, 4, 4), (2, 2, 2)),
+        ((4, 5, 4), (2, 2, 2)),
+        ((4, 4, 5), (2, 2, 2)),
+    ],
+)
+def test_bin_mean_3d_requires_exact_division(shape, bin_sizes):
+    arr = np.zeros(shape, dtype=np.float32)
+    bw, bh, bd = bin_sizes
+    with pytest.raises(ValueError):
+        ops.bin_mean_3d(arr, bw, bh, bd)


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
`bin_mean_3d` builds sub-stacks in Python and repeatedly calls `binned_mean_2d`, which adds Python-loop overhead and slows down ball-kernel generation for large inputs.

**What does this PR do?**
Vectorizes `bin_mean_3d` using a single reshape + mean to compute all bins in one NumPy operation.

## References

Closes #584 
## How has this PR been tested?

`pytest tests/core/test_unit`. 

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
