### PR TITLE
Add fields for setting voxel size during curation

### DIFF
--- a/cellfinder/napari/curation.py
+++ b/cellfinder/napari/curation.py
@@ -1,3 +1,4 @@
+from functools import partial
 from pathlib import Path
 from typing import List, Optional, Tuple
 
@@ -12,7 +13,11 @@ from magicgui.widgets import ProgressBar
 from napari.qt.threading import thread_worker
 from napari.utils.notifications import show_info
 from qt_niu.dialog import display_info, display_warning
-from qt_niu.interaction import add_button, add_combobox
+from qt_niu.interaction import (
+    add_button,
+    add_combobox,
+    add_float_box,
+)
 from qtpy import QtCore
 from qtpy.QtWidgets import (
     QComboBox,
@@ -159,6 +164,9 @@ class CurationWidget(QWidget):
 
         self.setLayout(self.layout)
 
+    def _set_voxel_size(self, value: float, index: int) -> None:
+        self.voxel_sizes[index] = value
+
     def add_loading_panel(self, row: int, column: int = 0):
         self.load_data_panel = QGroupBox("Load data")
         self.load_data_layout = QGridLayout()
@@ -180,32 +188,68 @@ class CurationWidget(QWidget):
             2,
             callback=self.set_background_image,
         )
+        box_z = add_float_box(
+            self.load_data_layout,
+            self.voxel_sizes[0],
+            0,
+            1000,
+            "Voxel size (z)",
+            0.01,
+            tooltip="Size of your voxels in the axial dimension (microns)",
+            row=3,
+        )
+        box_z.valueChanged.connect(partial(self._set_voxel_size, index=0))
+        box_y = add_float_box(
+            self.load_data_layout,
+            self.voxel_sizes[1],
+            0,
+            1000,
+            "Voxel size (y)",
+            0.01,
+            tooltip="Size of your voxels in the y direction "
+            "(top to bottom) (microns)",
+            row=4,
+        )
+        box_y.valueChanged.connect(partial(self._set_voxel_size, index=1))
+        box_x = add_float_box(
+            self.load_data_layout,
+            self.voxel_sizes[2],
+            0,
+            1000,
+            "Voxel size (x)",
+            0.01,
+            tooltip="Size of your voxels in the x direction "
+            "(left to right) (microns)",
+            row=5,
+        )
+        box_x.valueChanged.connect(partial(self._set_voxel_size, index=2))
+        self.voxel_sizes_boxes = box_z, box_y, box_x
         self.training_data_cell_choice, _ = add_combobox(
             self.load_data_layout,
             "Training data (cells)",
             self.point_layer_names,
-            3,
+            6,
             callback=self.set_training_data_cell,
         )
         self.training_data_non_cell_choice, _ = add_combobox(
             self.load_data_layout,
             "Training_data (non_cells)",
             self.point_layer_names,
-            row=4,
+            row=7,
             callback=self.set_training_data_non_cell,
         )
         self.mark_as_cell_button = add_button(
             "Mark as cell(s)",
             self.load_data_layout,
             self.mark_as_cell,
-            row=5,
+            row=8,
             tooltip="Mark all selected points as non cell. Shortcut: 'c'",
         )
         self.mark_as_non_cell_button = add_button(
             "Mark as non cell(s)",
             self.load_data_layout,
             self.mark_as_non_cell,
-            row=5,
+            row=8,
             column=1,
             tooltip="Mark all selected points as non cell. Shortcut: 'x'",
         )
@@ -213,13 +257,13 @@ class CurationWidget(QWidget):
             "Add training data layers",
             self.load_data_layout,
             self.add_training_data,
-            row=6,
+            row=9,
         )
         self.save_training_data_button = add_button(
             "Save training data",
             self.load_data_layout,
             self.save_training_data,
-            row=6,
+            row=9,
             column=1,
         )
         self.load_data_layout.setColumnMinimumWidth(0, COLUMN_WIDTH)

--- a/tests/napari/test_curation.py
+++ b/tests/napari/test_curation.py
@@ -12,7 +12,7 @@ from cellfinder.napari.sample_data import load_sample
 
 
 @pytest.fixture
-def curation_widget(make_napari_viewer):
+def curation_widget(make_napari_viewer) -> CurationWidget:
     """
     Create a viewer, add the curation widget, and return the widget.
     The viewer can be accessed using ``widget.viewer``.
@@ -36,6 +36,14 @@ def test_add_new_training_layers(curation_widget):
 
     assert layers[0].name == "Training data (cells)"
     assert layers[1].name == "Training data (non cells)"
+
+
+def test_update_voxel_size(curation_widget: CurationWidget):
+    assert curation_widget.voxel_sizes == [5, 2, 2]
+    curation_widget.voxel_sizes_boxes[0].setValue(3)
+    curation_widget.voxel_sizes_boxes[1].setValue(4)
+    curation_widget.voxel_sizes_boxes[2].setValue(5)
+    assert curation_widget.voxel_sizes == [3, 4, 5]
 
 
 def test_cell_marking(curation_widget, tmp_path):


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Currently there's no way to set the data's voxel sizes during training data curation, instead it's hard-coded. But we need to be able to set it specifically to the dataset.

**What does this PR do?**

It adds fields to be able to specify the 3-dim voxel sizes.

## References

None.

## How has this PR been tested?

Added a test, but also I used it as part of the original caching PR when curating my own dataset.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
