### PR TITLE
Fix: Show 'Done' popup after training data cubes are fully saved

### DIFF
--- a/cellfinder/napari/curation.py
+++ b/cellfinder/napari/curation.py
@@ -461,10 +461,10 @@ class CurationWidget(QWidget):
         else:
 
             @thread_worker(
-                    connect={
-                        "yielded": self.update_progress,
-                        "finished" : self._on_training_data_saved,
-                        }
+                connect={
+                    "yielded": self.update_progress,
+                    "finished": self._on_training_data_saved,
+                }
             )
             def extract_cubes():
                 yield from self.extract_cubes()

--- a/cellfinder/napari/curation.py
+++ b/cellfinder/napari/curation.py
@@ -404,6 +404,11 @@ class CurationWidget(QWidget):
         if self.is_data_extractable():
             if prompt_for_directory:
                 self.get_output_directory()
+
+                if self.output_directory is None:
+                    self.update_status_label("Ready")
+                    return
+
                 # if the directory is not empty
                 if any(self.output_directory.iterdir()):
                     choice = display_warning(
@@ -415,11 +420,8 @@ class CurationWidget(QWidget):
                         return
             if self.output_directory is not None:
                 self.__prep_directories_for_save()
-                self.__extract_cubes(block=block)
                 self.__save_yaml_file()
-                show_info("Done")
-
-            self.update_status_label("Ready")
+                self.__extract_cubes(block=block)
 
     def __prep_directories_for_save(self):
         self.yaml_filename = self.output_directory / "training.yaml"
@@ -458,11 +460,21 @@ class CurationWidget(QWidget):
                     break
         else:
 
-            @thread_worker(connect={"yielded": self.update_progress})
+            @thread_worker(
+                    connect={
+                        "yielded": self.update_progress,
+                        "finished" : self._on_training_data_saved,
+                        }
+            )
             def extract_cubes():
                 yield from self.extract_cubes()
 
             extract_cubes()
+
+    def _on_training_data_saved(self):
+        self.progress_bar.value = self.progress_bar.max
+        self.update_status_label("Ready")
+        show_info("Done")
 
     def is_data_extractable(self) -> bool:
         if (


### PR DESCRIPTION
This PR addresses issue #548, where the "Done" notification appeared immediately upon starting the training data export, regardless of actual progress.
Key Changes
Synchronized Notifications: Moved the show_info("Done") and status updates into a new callback method,
_on_training_data_saved.
Signal Connection: Connected the thread_worker's finished signal to the new callback to ensure the UI only resets after the background process is 100% complete.
Workflow Optimization: Relocated self.__save_yaml_file() to run before cube extraction, ensuring metadata is preserved even if the extraction process is interrupted.
Robust Directory Handling: Improved the directory selection check in save_training_data to reset the status to "Ready" if the user cancels the folder selection dialog.
Testing / How to verify:
Launch: Open Napari and load the Curation widget.
Data Setup:
Load signal and background images.
Add training data layers and annotate at least one point in both the "cells" and "non-cells" layers.
Execution: Click Save training data.
Verification:
Observe that the "Done" popup does not appear immediately.
Confirm the progress bar reaches the end and the "Done" message appears only after all cubes are written to the disk.