### PR TITLE
Fix setuptools_scm fallback version for editable installs 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,9 @@ include = ["cellfinder*"]
 include = ["cellfinder*"]
 
 [tool.setuptools_scm]
+version_scheme = "post-release"
+local_scheme = "node-and-date"
+fallback_version = "1.0.0"
 
 [tool.pytest.ini_options]
 addopts = "--cov=cellfinder"


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [x] Other (packaging configuration improvement)

**Why is this PR needed?**

When installing the package in editable mode (`pip install -e .`), the version reported by the package may be incorrect or missing if Git metadata cannot be resolved. This can cause inconsistent version reporting during development.

**What does this PR do?**

This PR configures `setuptools_scm` in `pyproject.toml` by adding:

- version_scheme = "post-release"
- local_scheme = "node-and-date"
- fallback_version = "1.0.0"

The fallback version ensures that a valid version is reported even when Git metadata is unavailable during editable installs.

## References

Fixes #551

## How has this PR been tested?

Tested locally by reinstalling the package in editable mode:

pip uninstall cellfinder
pip install -e .

Then verifying the version in Python:

import cellfinder
print(cellfinder.__version__)

The package correctly reports a version generated by `setuptools_scm`.

## Is this a breaking change?

No. This change only affects version generation and does not modify runtime functionality.

## Does this PR require an update to the documentation?

No documentation changes are required since this is an internal packaging configuration change.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with pre-commit