### PR TITLE
Remove unused detection constants

### DIFF
--- a/cellfinder/napari/detect/detect.py
+++ b/cellfinder/napari/detect/detect.py
@@ -31,8 +31,6 @@ from .detect_containers import (
 from .thread_worker import Worker
 
 NETWORK_VOXEL_SIZES = [5, 1, 1]
-CUBE_WIDTH = 50
-CUBE_HEIGHT = 50
 CUBE_DEPTH = 20
 
 # If using ROI, how many extra planes to analyse


### PR DESCRIPTION
## Description

**What is this PR?**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Refactoring
- [ ] Documentation update

## What does this PR do?

This PR removes unused constants from `cellfinder/napari/detect/detect.py`.

Removed:
- `CUBE_WIDTH`
- `CUBE_HEIGHT`

Kept:
- `CUBE_DEPTH`
- `NETWORK_VOXEL_SIZES`

`CUBE_DEPTH` and `NETWORK_VOXEL_SIZES[0]` are still used in the detection code path, so they remain unchanged.

I left `cellfinder/core/train/train_yaml.py` unchanged because the corresponding cube dimensions are still used there.

## Linked issues

Closes #601
