### PR TITLE
Add 2D input support for detection with clear guardrails

### DIFF
--- a/cellfinder/core/classify/classify.py
+++ b/cellfinder/core/classify/classify.py
@@ -90,9 +90,19 @@ def main(
         A callback function that is called during classification. Called with
         the batch number once that batch has been classified.
     """
-    if signal_array.ndim != 3:
-        raise IOError("Signal data must be 3D")
-    if background_array.ndim != 3:
+    if signal_array.ndim == 2:
+        if background_array.ndim != 2:
+            raise IOError("For 2D signal data, background must also be 2D")
+        if cube_depth != 1:
+            raise ValueError(
+                "For 2D data, cube_depth must be 1. "
+                "Train/use a 2D classifier or set skip_classification."
+            )
+        signal_array = signal_array[None, ...]
+        background_array = background_array[None, ...]
+    elif signal_array.ndim != 3:
+        raise IOError("Signal data must be 2D or 3D")
+    elif background_array.ndim != 3:
         raise IOError("Background data must be 3D")
 
     # Too many workers doesn't increase speed, and uses huge amounts of RAM
@@ -101,6 +111,8 @@ def main(
 
     start_time = datetime.now()
 
+    if len(voxel_sizes) == 2:
+        voxel_sizes = (1.0, *voxel_sizes)
     voxel_sizes = list(map(float, voxel_sizes))
     logger.debug("Initialising cube generator")
     dataset = CuboidArrayDataset(

--- a/cellfinder/core/detect/detect.py
+++ b/cellfinder/core/detect/detect.py
@@ -66,6 +66,7 @@ def main(
     ----------
     signal_array : numpy.ndarray or dask array
         3D array representing the signal data in z, y, x order.
+        2D arrays are also accepted and treated as a single z-plane.
     start_plane : int
         First plane index to process (inclusive, to process a subset of the
         data).
@@ -176,8 +177,23 @@ def main(
             f"{signal_array.dtype}"
         )
 
-    if signal_array.ndim != 3:
-        raise ValueError("Input data must be 3D")
+    is_2d = False
+    if signal_array.ndim == 2:
+        is_2d = True
+        signal_array = signal_array[None, ...]
+    elif signal_array.ndim != 3:
+        raise ValueError("Input data must be 2D or 3D")
+
+    if is_2d:
+        if start_plane != 0:
+            raise ValueError("For 2D data, start_plane must be 0.")
+        if end_plane not in (-1, 1):
+            raise ValueError(
+                "For 2D data, end_plane must be 1 (or -1 for default)."
+            )
+        end_plane = 1
+        ball_z_size = 1
+        split_ball_z_size = 1
 
     if end_plane < 0:
         end_plane = len(signal_array)
@@ -192,6 +208,8 @@ def main(
 
     batch_size = max(batch_size, 1)
     # brainmapper can pass them in as str
+    if len(voxel_sizes) == 2:
+        voxel_sizes = (1.0, *voxel_sizes)
     voxel_sizes = list(map(float, voxel_sizes))
 
     settings = DetectionSettings(

--- a/cellfinder/core/main.py
+++ b/cellfinder/core/main.py
@@ -55,10 +55,13 @@ def main(
     ----------
     signal_array : numpy.ndarray or dask array
         3D array representing the signal data in z, y, x order.
+        2D arrays are also accepted and treated as a single z-plane.
     background_array : numpy.ndarray or dask array
         3D array representing the signal data in z, y, x order.
+        2D arrays are also accepted and treated as a single z-plane.
     voxel_sizes : 3-tuple of floats
         Size of your voxels in the z, y, and x dimensions (microns).
+        For 2D inputs, you may pass a 2-tuple (y, x); z is assumed to be 1.0.
     start_plane : int
         First plane index to process (inclusive, to process a subset of the
         data).
@@ -187,6 +190,20 @@ def main(
     from cellfinder.core.classify import classify
     from cellfinder.core.detect import detect
     from cellfinder.core.tools import prep
+
+    if signal_array.ndim == 2:
+        if background_array.ndim != 2:
+            raise ValueError(
+                "For 2D signal inputs, background_array must also be 2D."
+            )
+        if not skip_classification:
+            raise ValueError(
+                "2D classification is not supported in this pipeline yet. "
+                "Set skip_classification=True to run detection only, or "
+                "train a dedicated 2D classifier and wire it in."
+            )
+        if len(voxel_sizes) == 2:
+            voxel_sizes = (1.0, *voxel_sizes)
 
     if not skip_detection:
         logger.info("Detecting cell candidates")


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [ ] Bug fix
- [yes] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
To allow 2D microscopy inputs to run through the detection pipeline safely. This unblocks users working with single‑plane data and provides clear guardrails around unsupported 2D classification.

**What does this PR do?**
Accepts 2D inputs for detection and treats them as a single z‑plane.
Forces z‑dependent filter parameters to 1 in 2D mode.
Pads voxel_sizes from (y, x) to (1.0, y, x) for 2D.
Adds guardrails and clearer errors in the main pipeline and classifier entry point for 2D usage.

Please reference any existing issues/PRs that relate to this PR.

## How has this PR been tested?
None yet

Please explain how any new code has been tested, and how you have ensured that no existing functionality has changed.

## Is this a breaking change?
No. Existing 3D workflows are unchanged. 2D inputs now have explicit validation.

If this PR breaks any existing functionality, please explain how and why.
No. Existing 3D workflows are unchanged. The new logic only activates for 2D inputs and adds explicit validation/guardrails.

## Does this PR require an update to the documentation?
Yes. Usage docs should mention that 2D detection is supported but classification is not yet implemented for 2D.

If any features have changed, or have been added. Please explain how the documentation has been updated (and link to the associated PR). See [here](https://brainglobe.info/community/developers/index.html#to-improve-the-documentation) for details.

## Checklist:

- [yes ] The code has been tested locally
- [no ] Tests have been added to cover all new functionality (unit & integration)
- [ no] The documentation has been updated to reflect any changes
- [ yes] The code has been formatted with [pre-commit](https://pre-commit.com/)
