### PR TITLE
Fix #605: make background_array optional when skip_classification=True

### DIFF
--- a/cellfinder/core/main.py
+++ b/cellfinder/core/main.py
@@ -10,8 +10,8 @@ from cellfinder.core.train.train_yaml import depth_type
 
 def main(
     signal_array: types.array,
-    background_array: Optional[types.array] = None,
     voxel_sizes: Tuple[float, float, float],
+    background_array: Optional[types.array] = None,
     start_plane: int = 0,
     end_plane: int = -1,
     trained_model: Optional[os.PathLike] = None,
@@ -55,10 +55,11 @@ def main(
     ----------
     signal_array : numpy.ndarray or dask array
         3D array representing the signal data in z, y, x order.
-    background_array : numpy.ndarray or dask array
-        3D array representing the signal data in z, y, x order.
     voxel_sizes : 3-tuple of floats
         Size of your voxels in the z, y, and x dimensions (microns).
+    background_array : numpy.ndarray or dask array, optional
+        3D array representing the background data in z, y, x order.
+        Required when skip_classification=False. Defaults to None.
     start_plane : int
         First plane index to process (inclusive, to process a subset of the
         data).
@@ -226,7 +227,8 @@ def main(
     if not skip_classification:
         if background_array is None:
             raise ValueError(
-                "background_array is required when skip_classification=False"
+                "background_array is required when "
+                "skip_classification=False"
             )
         install_path = None
         model_weights = prep.prep_model_weights(

--- a/cellfinder/core/main.py
+++ b/cellfinder/core/main.py
@@ -10,7 +10,7 @@ from cellfinder.core.train.train_yaml import depth_type
 
 def main(
     signal_array: types.array,
-    background_array: types.array,
+    background_array: Optional[types.array] = None,
     voxel_sizes: Tuple[float, float, float],
     start_plane: int = 0,
     end_plane: int = -1,
@@ -224,6 +224,10 @@ def main(
         detect_finished_callback(points)
 
     if not skip_classification:
+        if background_array is None:
+            raise ValueError(
+                "background_array is required when skip_classification=False"
+            )
         install_path = None
         model_weights = prep.prep_model_weights(
             model_weights, install_path, model


### PR DESCRIPTION
Background_array was always required even when skip_classification=True. This fix makes it default to None and adds
ValueError with a clear  message when classification is attempted without a background array.

Fixes #605

Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

background_array was always a required argument even when skip_classification=True. This blocked researchers who only have 
a single channel (signal only) from using cellfinder for detection  without classification.

**What does this PR do?**

- Makes background_array default to None instead of being required
- Adds a clear ValueError message if someone tries to run 
  classification without providing background_array
- Updates the docstring to reflect that background_array is optional

## References

Fixes #605
Related to #352

## How has this PR been tested?

Manually verified that calling main() with skip_classification=True and no background_array no longer raises a TypeError.
Also verified that calling main() with skip_classification=False and no background_array now raises a clear ValueError.

## Is this a breaking change?
No. Users who already pass background_array will see no change. Users who pass skip_classification=True without background_array  will now get the expected behaviour instead of a TypeError.

## Does this PR require an update to the documentation?

The docstring for background_array in main() has been updated  to reflect it is now optional.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
