### PR TITLE
Validate model inputs before running detection

### DIFF
--- a/cellfinder/core/main.py
+++ b/cellfinder/core/main.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from typing import Callable, List, Optional, Tuple
 
 from brainglobe_utils.cells.cells import Cell
@@ -188,6 +189,16 @@ def main(
     from cellfinder.core.detect import detect
     from cellfinder.core.tools import prep
 
+    if not skip_classification:
+        if trained_model is not None and not Path(trained_model).exists():
+            raise FileNotFoundError(
+                f"Trained model not found: {trained_model}"
+            )
+        install_path = None
+        model_weights = prep.prep_model_weights(
+            model_weights, install_path, model
+        )
+
     if not skip_detection:
         logger.info("Detecting cell candidates")
 
@@ -224,10 +235,6 @@ def main(
         detect_finished_callback(points)
 
     if not skip_classification:
-        install_path = None
-        model_weights = prep.prep_model_weights(
-            model_weights, install_path, model
-        )
         if len(points) > 0:
             logger.info("Running classification")
             points = classify.main(

--- a/cellfinder/core/tools/prep.py
+++ b/cellfinder/core/tools/prep.py
@@ -56,6 +56,10 @@ def prep_models(
             model_weights = get_model_weights(config_file)
     else:
         model_weights = Path(model_weights_path)
+        if not model_weights.exists():
+            raise FileNotFoundError(
+                f"Model weights not found: {model_weights}"
+            )
     return model_weights
 
 

--- a/tests/core/test_unit/test_main.py
+++ b/tests/core/test_unit/test_main.py
@@ -1,0 +1,65 @@
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from cellfinder.core.main import main
+
+
+@pytest.fixture
+def signal_array():
+    return np.empty((5, 50, 50), dtype=np.uint16)
+
+
+@pytest.fixture
+def background_array():
+    return np.empty((5, 50, 50), dtype=np.uint16)
+
+
+@patch("cellfinder.core.detect.detect.main")
+def test_invalid_trained_model_fails_before_detection(
+    mock_detect, signal_array, background_array
+):
+    with pytest.raises(FileNotFoundError, match="Trained model not found"):
+        main(
+            signal_array=signal_array,
+            background_array=background_array,
+            voxel_sizes=(5, 2, 2),
+            trained_model="/nonexistent/model.keras",
+        )
+
+    mock_detect.assert_not_called()
+
+
+@patch("cellfinder.core.detect.detect.main")
+def test_invalid_model_weights_fails_before_detection(
+    mock_detect, signal_array, background_array, tmp_path
+):
+    bad_weights = tmp_path / "nonexistent_weights.h5"
+
+    with pytest.raises(FileNotFoundError, match="Model weights not found"):
+        main(
+            signal_array=signal_array,
+            background_array=background_array,
+            voxel_sizes=(5, 2, 2),
+            model_weights=bad_weights,
+        )
+
+    mock_detect.assert_not_called()
+
+
+@patch("cellfinder.core.detect.detect.main", return_value=[])
+@patch("cellfinder.core.tools.prep.prep_model_weights")
+def test_valid_weights_allows_detection(
+    mock_prep_weights, mock_detect, signal_array, background_array
+):
+    mock_prep_weights.return_value = "/some/weights.h5"
+
+    main(
+        signal_array=signal_array,
+        background_array=background_array,
+        voxel_sizes=(5, 2, 2),
+    )
+
+    mock_prep_weights.assert_called_once()
+    mock_detect.assert_called_once()


### PR DESCRIPTION
If classification is enabled but the model or weights path is wrong,
cellfinder runs the entire detection before hitting the error. This
moves the validation to happen first so it fails fast.

Addresses #337

`prep_model_weights` now runs before detection starts. Also added a
check in `prep_models` for when a user passes a custom weights path
that doesn't exist.

Run `python -m pytest tests/core/test_unit/test_main.py -v`