### PR TITLE
fix: allow detection-only runs without background channel

### DIFF
--- a/cellfinder/core/main.py
+++ b/cellfinder/core/main.py
@@ -10,8 +10,8 @@ from cellfinder.core.train.train_yaml import depth_type
 
 def main(
     signal_array: types.array,
-    background_array: types.array,
-    voxel_sizes: Tuple[float, float, float],
+    background_array: types.array | Tuple[float, float, float] | None = None,
+    voxel_sizes: Tuple[float, float, float] | None = None,
     start_plane: int = 0,
     end_plane: int = -1,
     trained_model: Optional[os.PathLike] = None,
@@ -55,8 +55,10 @@ def main(
     ----------
     signal_array : numpy.ndarray or dask array
         3D array representing the signal data in z, y, x order.
-    background_array : numpy.ndarray or dask array
-        3D array representing the signal data in z, y, x order.
+    background_array : numpy.ndarray or dask array, optional
+        3D array representing the background data in z, y, x order. This is
+        required when classification is enabled and optional when
+        ``skip_classification=True``.
     voxel_sizes : 3-tuple of floats
         Size of your voxels in the z, y, and x dimensions (microns).
     start_plane : int
@@ -187,6 +189,21 @@ def main(
     from cellfinder.core.classify import classify
     from cellfinder.core.detect import detect
     from cellfinder.core.tools import prep
+
+    # Preserve the historical positional API while allowing callers to omit
+    # background data for detection-only runs.
+    if voxel_sizes is None:
+        voxel_sizes = background_array
+        background_array = None
+
+    if voxel_sizes is None:
+        raise TypeError("voxel_sizes must be provided")
+
+    if not skip_classification and background_array is None:
+        raise ValueError(
+            "background_array must be provided unless "
+            "skip_classification=True"
+        )
 
     if not skip_detection:
         logger.info("Detecting cell candidates")

--- a/tests/core/test_integration/test_detection.py
+++ b/tests/core/test_integration/test_detection.py
@@ -189,6 +189,35 @@ def test_synthetic_data(synthetic_bright_spots, no_free_cpus):
     assert len(detected) == 8
 
 
+def test_skip_classification_without_background_array(
+    synthetic_single_spot, no_free_cpus
+):
+    signal_array, _, center = synthetic_single_spot
+    detected = main(
+        signal_array=signal_array.astype(np.float32),
+        voxel_sizes=voxel_sizes,
+        n_sds_above_mean_thresh=1.0,
+        n_free_cpus=no_free_cpus,
+        skip_classification=True,
+    )
+
+    assert len(detected) == 1
+    assert detected[0] == Cell(center, Cell.UNKNOWN)
+
+
+def test_background_array_required_for_classification():
+    signal_array = np.zeros((5, 5, 5), dtype=np.float32)
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "background_array must be provided unless "
+            "skip_classification=True"
+        ),
+    ):
+        main(signal_array=signal_array, voxel_sizes=voxel_sizes)
+
+
 @pytest.mark.parametrize("ndim", [1, 2, 4])
 def test_data_dimension_error(ndim):
     # Check for an error when non-3D data input


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

`cellfinder.core.main.main(...)` currently requires a `background_array` even when `skip_classification=True`.

That blocks single-channel detection-only use cases and causes the Python API to fail before the skip-classification logic is reached. This is also a concrete blocker related to optional-background support discussed in #352.

**What does this PR do?**

- makes `background_array` optional at the `cellfinder.core.main.main(...)` entrypoint
- allows detection-only runs when `skip_classification=True` and no background channel is provided
- preserves the requirement for `background_array` when classification is enabled
- adds regression tests for both the allowed detection-only case and the classification-required error case

## References

- Closes #605
- Related to #352

## How has this PR been tested?

I added regression tests covering:
- detection-only execution without `background_array`
- raising a clear error when classification is requested without `background_array`

I also manually reviewed the changed code paths to ensure classification still requires background input.


## Is this a breaking change?

No.

This change preserves existing behavior for classification workflows and only relaxes the API for detection-only runs when `skip_classification=True`.

## Does this PR require an update to the documentation?

No documentation changes were made in this PR.

This is a small bug fix to the Python API behavior. If preferred, I’m happy to add a short note to the API docs in a follow-up PR.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
