### PR TITLE
Fix cellfinder train CLI + CLI smoke tests

### DIFF
--- a/cellfinder/core/train/train_yaml.py
+++ b/cellfinder/core/train/train_yaml.py
@@ -223,7 +223,7 @@ def training_parse():
         type=check_positive_float,
         default=0.9,
         help="Value `[0, 1]` with the probability of a data item being "
-        "augmented. I.e. `0.9` means 90% of the data will have been "
+        "augmented. I.e. `0.9` means 90%% of the data will have been "
         "augmented.",
     )
     training_parser.add_argument(

--- a/tests/core/test_integration/test_cli_help.py
+++ b/tests/core/test_integration/test_cli_help.py
@@ -1,0 +1,26 @@
+"""Smoke tests ensuring CLI --help option exits without failure"""
+
+import subprocess
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "entry_point",
+    [
+        "cellfinder_download",
+        "cellfinder_train",
+        "cellfinder",
+    ],
+)
+def test_cli_help(entry_point):
+    result = subprocess.run(
+        [entry_point, "--help"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"`{entry_point} --help` exited with code {result.returncode}\n"
+        f"stdout: {result.stdout}\n"
+        f"stderr: {result.stderr}"
+    )


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**What does this PR do?**

- fixes bug found in https://github.com/conda-forge/cellfinder-feedstock/actions/runs/26215976079/job/77138310276#step:3:2059
- ensures we catch similar bugs earlier next time, by adding a smoketest for all CLI --help options


Tested manually that new tests fail on current main, for `cellfinder_train` with the same error as on the linked `conda-forge` CI, and that the error message gets printed on failure.
