### PR TITLE
feat: make main functions' arguments keyword-only with deprecation wrapper

### DIFF
--- a/benchmarks/detect_and_classify.py
+++ b/benchmarks/detect_and_classify.py
@@ -21,4 +21,9 @@ logger.debug(f"Signal array size = {array_size_MB:.02f} MB")
 
 if __name__ == "__main__":
     # Run detection & classification
-    main(signal_array, background_array, voxel_sizes, n_free_cpus=0)
+    main(
+        signal_array=signal_array,
+        background_array=background_array,
+        voxel_sizes=voxel_sizes,
+        n_free_cpus=0,
+    )

--- a/cellfinder/core/classify/classify.py
+++ b/cellfinder/core/classify/classify.py
@@ -16,8 +16,9 @@ from cellfinder.core.classify.cube_generator import (
     CuboidBatchSampler,
 )
 from cellfinder.core.classify.tools import get_model
-from cellfinder.core.train.train_yaml import depth_type, models
 from cellfinder.core.tools.tools import deprecate_positional_args
+from cellfinder.core.train.train_yaml import depth_type, models
+
 
 @deprecate_positional_args
 def main(

--- a/cellfinder/core/classify/classify.py
+++ b/cellfinder/core/classify/classify.py
@@ -17,9 +17,11 @@ from cellfinder.core.classify.cube_generator import (
 )
 from cellfinder.core.classify.tools import get_model
 from cellfinder.core.train.train_yaml import depth_type, models
+from cellfinder.core.tools.tools import deprecate_positional_args
 
-
+@deprecate_positional_args
 def main(
+    *,
     points: List[Cell],
     signal_array: types.array,
     background_array: types.array,
@@ -35,7 +37,6 @@ def main(
     network_depth: depth_type,
     max_workers: int = 3,
     pin_memory: bool = False,
-    *,
     callback: Optional[Callable[[int], None]] = None,
 ) -> List[Cell]:
     """

--- a/cellfinder/core/detect/detect.py
+++ b/cellfinder/core/detect/detect.py
@@ -25,11 +25,13 @@ from cellfinder.core import logger, types
 from cellfinder.core.detect.filters.plane import TileProcessor
 from cellfinder.core.detect.filters.setup_filters import DetectionSettings
 from cellfinder.core.detect.filters.volume.volume_filter import VolumeFilter
-from cellfinder.core.tools.tools import inference_wrapper
+from cellfinder.core.tools.tools import deprecate_positional_args, inference_wrapper
 
 
+@deprecate_positional_args
 @inference_wrapper
 def main(
+    *,
     signal_array: types.array,
     start_plane: int = 0,
     end_plane: int = -1,
@@ -56,7 +58,6 @@ def main(
     n_splitting_iter: int = 10,
     n_sds_above_mean_tiled_thresh: float = 10,
     tiled_thresh_tile_size: float | None = None,
-    *,
     callback: Optional[Callable[[int], None]] = None,
 ) -> List[Cell]:
     """

--- a/cellfinder/core/detect/detect.py
+++ b/cellfinder/core/detect/detect.py
@@ -25,7 +25,10 @@ from cellfinder.core import logger, types
 from cellfinder.core.detect.filters.plane import TileProcessor
 from cellfinder.core.detect.filters.setup_filters import DetectionSettings
 from cellfinder.core.detect.filters.volume.volume_filter import VolumeFilter
-from cellfinder.core.tools.tools import deprecate_positional_args, inference_wrapper
+from cellfinder.core.tools.tools import (
+    deprecate_positional_args,
+    inference_wrapper,
+)
 
 
 @deprecate_positional_args

--- a/cellfinder/core/main.py
+++ b/cellfinder/core/main.py
@@ -6,8 +6,8 @@ from brainglobe_utils.cells.cells import Cell
 
 from cellfinder.core import logger, types
 from cellfinder.core.download.download import model_type
-from cellfinder.core.train.train_yaml import depth_type
 from cellfinder.core.tools.tools import deprecate_positional_args
+from cellfinder.core.train.train_yaml import depth_type
 
 
 @deprecate_positional_args

--- a/cellfinder/core/main.py
+++ b/cellfinder/core/main.py
@@ -7,9 +7,12 @@ from brainglobe_utils.cells.cells import Cell
 from cellfinder.core import logger, types
 from cellfinder.core.download.download import model_type
 from cellfinder.core.train.train_yaml import depth_type
+from cellfinder.core.tools.tools import deprecate_positional_args
 
 
+@deprecate_positional_args
 def main(
+    *,
     signal_array: types.array,
     background_array: types.array,
     voxel_sizes: Tuple[float, float, float],
@@ -45,7 +48,6 @@ def main(
     n_splitting_iter: int = 10,
     n_sds_above_mean_tiled_thresh: float = 10,
     tiled_thresh_tile_size: float | None = None,
-    *,
     detect_callback: Optional[Callable[[int], None]] = None,
     classify_callback: Optional[Callable[[int], None]] = None,
     detect_finished_callback: Optional[Callable[[list], None]] = None,
@@ -238,19 +240,19 @@ def main(
         if len(points) > 0:
             logger.info("Running classification")
             points = classify.main(
-                points,
-                signal_array,
-                background_array,
-                n_free_cpus,
-                voxel_sizes,
-                network_voxel_sizes,
-                classification_batch_size,
-                cube_height,
-                cube_width,
-                cube_depth,
-                trained_model,
-                model_weights,
-                network_depth,
+                points=points,
+                signal_array=signal_array,
+                background_array=background_array,
+                n_free_cpus=n_free_cpus,
+                voxel_sizes=voxel_sizes,
+                network_voxel_sizes=network_voxel_sizes,
+                batch_size=classification_batch_size,
+                cube_height=cube_height,
+                cube_width=cube_width,
+                cube_depth=cube_depth,
+                trained_model=trained_model,
+                model_weights=model_weights,
+                network_depth=network_depth,
                 callback=classify_callback,
                 max_workers=classification_max_workers,
             )

--- a/cellfinder/core/tools/tools.py
+++ b/cellfinder/core/tools/tools.py
@@ -357,7 +357,10 @@ def deprecate_positional_args(func):
         name
         for name, param in sig.parameters.items()
         if param.kind
-        not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+        not in (
+            inspect.Parameter.VAR_POSITIONAL,
+            inspect.Parameter.VAR_KEYWORD,
+        )
     ]
 
     @wraps(func)

--- a/cellfinder/core/tools/tools.py
+++ b/cellfinder/core/tools/tools.py
@@ -345,35 +345,46 @@ def get_axis_reordering(
 
 def deprecate_positional_args(func):
     """
-    Decorator to deprecate positional arguments and map them to keyword arguments.
-    Raises a DeprecationWarning if any positional arguments are used.
+    Decorator to deprecate positional arguments and map them to
+    keyword arguments. Raises a DeprecationWarning if any positional
+    arguments are used.
     """
     import inspect
     import warnings
 
     sig = inspect.signature(func)
     param_names = [
-        name for name, param in sig.parameters.items()
-        if param.kind not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+        name
+        for name, param in sig.parameters.items()
+        if param.kind
+        not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
     ]
 
     @wraps(func)
     def wrapper(*args, **kwargs):
         if args:
             warnings.warn(
-                f"Calling {func.__name__} with positional arguments is deprecated "
-                "and will be removed after a 6-12 month grace period. Please use keyword arguments.",
+                f"Calling {func.__name__} with positional arguments "
+                "is deprecated and will be removed after a 6-12 month "
+                "grace period. Please use keyword arguments.",
                 DeprecationWarning,
-                stacklevel=2
+                stacklevel=2,
             )
             for i, arg in enumerate(args):
                 if i < len(param_names):
                     if param_names[i] in kwargs:
-                        raise TypeError(f"{func.__name__} got multiple values for argument '{param_names[i]}'")
+                        raise TypeError(
+                            f"{func.__name__} got multiple values "
+                            f"for argument '{param_names[i]}'"
+                        )
                     kwargs[param_names[i]] = arg
                 else:
-                    raise TypeError(f"{func.__name__} takes {len(param_names)} positional arguments but {len(args)} were given")
-            
+                    raise TypeError(
+                        f"{func.__name__} takes {len(param_names)} "
+                        f"positional arguments but {len(args)} were given"
+                    )
+
             return func(**kwargs)
         return func(**kwargs)
+
     return wrapper

--- a/cellfinder/core/tools/tools.py
+++ b/cellfinder/core/tools/tools.py
@@ -341,3 +341,39 @@ def get_axis_reordering(
     for value in out_order:
         indices.append(in_order.index(value))
     return indices
+
+
+def deprecate_positional_args(func):
+    """
+    Decorator to deprecate positional arguments and map them to keyword arguments.
+    Raises a DeprecationWarning if any positional arguments are used.
+    """
+    import inspect
+    import warnings
+
+    sig = inspect.signature(func)
+    param_names = [
+        name for name, param in sig.parameters.items()
+        if param.kind not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+    ]
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        if args:
+            warnings.warn(
+                f"Calling {func.__name__} with positional arguments is deprecated "
+                "and will be removed after a 6-12 month grace period. Please use keyword arguments.",
+                DeprecationWarning,
+                stacklevel=2
+            )
+            for i, arg in enumerate(args):
+                if i < len(param_names):
+                    if param_names[i] in kwargs:
+                        raise TypeError(f"{func.__name__} got multiple values for argument '{param_names[i]}'")
+                    kwargs[param_names[i]] = arg
+                else:
+                    raise TypeError(f"{func.__name__} takes {len(param_names)} positional arguments but {len(args)} were given")
+            
+            return func(**kwargs)
+        return func(**kwargs)
+    return wrapper

--- a/cellfinder/core/tools/tools.py
+++ b/cellfinder/core/tools/tools.py
@@ -368,8 +368,8 @@ def deprecate_positional_args(func):
         if args:
             warnings.warn(
                 f"Calling {func.__name__} with positional arguments "
-                "is deprecated and will be removed after a 6-12 month "
-                "grace period. Please use keyword arguments.",
+                "is deprecated and will be removed in early 2027. "
+                "Please use keyword arguments.",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/tests/core/test_integration/test_detection.py
+++ b/tests/core/test_integration/test_detection.py
@@ -77,9 +77,9 @@ def count_matched_cells(cell_test, cell_validation, tolerance=0):
 def test_detection_full(signal_array, background_array, free_cpus, request):
     n_free_cpus = request.getfixturevalue(free_cpus)
     cells_test = main(
-        signal_array,
-        background_array,
-        voxel_sizes,
+        signal_array=signal_array,
+        background_array=background_array,
+        voxel_sizes=voxel_sizes,
         n_free_cpus=n_free_cpus,
     )
     cells_validation = cell_io.get_cells(cells_validation_xml)
@@ -128,9 +128,9 @@ def test_detection_small_planes(
     )
 
     main(
-        signal_array[0:n_planes],
-        background_array[0:n_planes],
-        voxel_sizes,
+        signal_array=signal_array[0:n_planes],
+        background_array=background_array[0:n_planes],
+        voxel_sizes=voxel_sizes,
         ball_z_size=5,
         n_free_cpus=no_free_cpus,
     )
@@ -155,9 +155,9 @@ def test_callbacks(signal_array, background_array, no_free_cpus):
         points_found.append(points)
 
     main(
-        signal_array,
-        background_array,
-        voxel_sizes,
+        signal_array=signal_array,
+        background_array=background_array,
+        voxel_sizes=voxel_sizes,
         detect_callback=detect_callback,
         classify_callback=classify_callback,
         detect_finished_callback=detect_finished_callback,
@@ -181,9 +181,9 @@ def test_callbacks(signal_array, background_array, no_free_cpus):
 def test_synthetic_data(synthetic_bright_spots, no_free_cpus):
     signal_array, background_array = synthetic_bright_spots
     detected = main(
-        signal_array,
-        background_array,
-        voxel_sizes,
+        signal_array=signal_array,
+        background_array=background_array,
+        voxel_sizes=voxel_sizes,
         n_free_cpus=no_free_cpus,
     )
     assert len(detected) == 8
@@ -201,7 +201,7 @@ def test_data_dimension_error(ndim):
     )
 
     with pytest.raises(ValueError, match="Input data must be 3D"):
-        main(signal_array, background_array, voxel_sizes)
+        main(signal_array=signal_array, background_array=background_array, voxel_sizes=voxel_sizes)
 
 
 @pytest.mark.parametrize("device", ["cuda", "cpu"])
@@ -234,8 +234,8 @@ def test_signal_data_types(synthetic_single_spot, no_free_cpus, dtype, device):
 
     background_array = background_array.astype(dtype)
     detected = main(
-        signal_array,
-        background_array,
+        signal_array=signal_array,
+        background_array=background_array,
         n_sds_above_mean_thresh=1.0,
         voxel_sizes=voxel_sizes,
         n_free_cpus=no_free_cpus,
@@ -257,7 +257,7 @@ def test_detection_scipy_torch(synthetic_single_spot, no_free_cpus, device):
     signal_array = signal_array.astype(np.float32)
 
     detected = detect_main(
-        signal_array,
+        signal_array=signal_array,
         n_sds_above_mean_thresh=1.0,
         voxel_sizes=voxel_sizes,
         n_free_cpus=no_free_cpus,
@@ -286,7 +286,7 @@ def test_detection_cluster_splitting(
     signal_array = signal_array.astype(np.float32)
 
     detected = detect_main(
-        signal_array,
+        signal_array=signal_array,
         n_sds_above_mean_thresh=1.0,
         voxel_sizes=voxel_sizes,
         n_free_cpus=no_free_cpus,
@@ -313,7 +313,7 @@ def test_detection_cell_too_large(synthetic_spot_clusters, no_free_cpus):
     signal_array[6 : 6 + 6, 40 : 40 + 26, 40 : 40 + 26] = 1000
 
     detected = detect_main(
-        signal_array,
+        signal_array=signal_array,
         n_sds_above_mean_thresh=1.0,
         voxel_sizes=(5, 2, 2),
         soma_diameter=20,
@@ -331,7 +331,7 @@ def test_detection_plane_too_small(synthetic_spot_clusters, y, x):
     # plane smaller than ball filter kernel should cause error
     with pytest.raises(InvalidVolume):
         detect_main(
-            np.zeros((5, y, x)),
+            signal_array=np.zeros((5, y, x)),
             n_sds_above_mean_thresh=1.0,
             voxel_sizes=(1, 1, 1),
             ball_xy_size=50,

--- a/tests/core/test_integration/test_detection.py
+++ b/tests/core/test_integration/test_detection.py
@@ -201,7 +201,11 @@ def test_data_dimension_error(ndim):
     )
 
     with pytest.raises(ValueError, match="Input data must be 3D"):
-        main(signal_array=signal_array, background_array=background_array, voxel_sizes=voxel_sizes)
+        main(
+            signal_array=signal_array,
+            background_array=background_array,
+            voxel_sizes=voxel_sizes,
+        )
 
 
 @pytest.mark.parametrize("device", ["cuda", "cpu"])

--- a/tests/core/test_integration/test_detection_structure_splitting.py
+++ b/tests/core/test_integration/test_detection_structure_splitting.py
@@ -52,9 +52,9 @@ def test_structure_splitting(signal_array, background_array):
     Smoke test to ensure structure splitting code doesn't break.
     """
     main(
-        signal_array,
-        background_array,
-        voxel_sizes,
+        signal_array=signal_array,
+        background_array=background_array,
+        voxel_sizes=voxel_sizes,
         n_free_cpus=0,
     )
 

--- a/tests/core/test_unit/test_tools/test_tools_general.py
+++ b/tests/core/test_unit/test_tools/test_tools_general.py
@@ -318,13 +318,21 @@ def test_deprecate_positional_args():
         assert len(w) == 0
 
     # 2. Positional arguments (Warning)
-    with pytest.warns(DeprecationWarning, match="Calling sample_func with positional arguments is deprecated"):
+    with pytest.warns(
+        DeprecationWarning,
+        match="Calling sample_func with positional arguments is deprecated",
+    ):
         assert sample_func(5, 3) == 8
 
     # 3. Both positional and keyword for same argument (TypeError)
-    with pytest.raises(TypeError, match="sample_func got multiple values for argument 'a'"):
+    with pytest.raises(
+        TypeError, match="sample_func got multiple values for argument 'a'"
+    ):
         sample_func(5, a=10)
 
     # 4. Too many positional arguments (TypeError)
-    with pytest.raises(TypeError, match="sample_func takes 2 positional arguments but 3 were given"):
+    with pytest.raises(
+        TypeError,
+        match="sample_func takes 2 positional arguments but 3 were given",
+    ):
         sample_func(1, 2, 3)

--- a/tests/core/test_unit/test_tools/test_tools_general.py
+++ b/tests/core/test_unit/test_tools/test_tools_general.py
@@ -302,3 +302,29 @@ def test_get_axis_reordering():
     assert torch.allclose(reordered, manual_reordered)
     # check data is not already symmetric in x, y
     assert data[0, 1, 5] != data[1, 0, 5]
+
+
+def test_deprecate_positional_args():
+    import warnings
+
+    @tools.deprecate_positional_args
+    def sample_func(*, a, b=2):
+        return a + b
+
+    # 1. Keyword arguments only (No warning)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        assert sample_func(a=5) == 7
+        assert len(w) == 0
+
+    # 2. Positional arguments (Warning)
+    with pytest.warns(DeprecationWarning, match="Calling sample_func with positional arguments is deprecated"):
+        assert sample_func(5, 3) == 8
+
+    # 3. Both positional and keyword for same argument (TypeError)
+    with pytest.raises(TypeError, match="sample_func got multiple values for argument 'a'"):
+        sample_func(5, a=10)
+
+    # 4. Too many positional arguments (TypeError)
+    with pytest.raises(TypeError, match="sample_func takes 2 positional arguments but 3 were given"):
+        sample_func(1, 2, 3)


### PR DESCRIPTION
Closes #550

## Summary
Converts `detect.main()`, `classify.main()`, and the root `main()` to
keyword-only arguments with a `@deprecate_positional_args` decorator
for a 6-12 month grace period before hard removal.

## Changes
- `cellfinder/core/tools/tools.py`: added reusable `deprecate_positional_args` decorator
- `cellfinder/core/detect/detect.py`: keyword-only signature + decorator applied
- `cellfinder/core/classify/classify.py`: keyword-only signature + decorator applied
- `cellfinder/core/main.py`: keyword-only signature + decorator applied; internal `classify.main()` call updated to keyword args
- `benchmarks/detect_and_classify.py`: updated to keyword args
- `tests/core/test_integration/test_detection.py`: updated to keyword args
- `tests/core/test_integration/test_detection_structure_splitting.py`: updated to keyword args

## Deprecation Approach
A `@deprecate_positional_args` decorator wraps each function. If a caller
passes positional arguments, the decorator:
1. Maps positional values to their corresponding keyword parameter names via `inspect.signature`
2. Emits a `DeprecationWarning` with `stacklevel=2` and mentions the 6-12 month grace period
3. Forwards everything as `**kwargs` to the keyword-only inner function

This ensures no abrupt `TypeError` for existing callers during the grace
period. Removal is as simple as deleting the decorator after 6-12 months.

## External Repos Checked
- `brainglobe-workflows` (brainmapper CLI): checked for positional calls , none found