### PR TITLE
Show "Done" only after training data is actually saved.

### DIFF
--- a/cellfinder/napari/curation.py
+++ b/cellfinder/napari/curation.py
@@ -469,10 +469,8 @@ class CurationWidget(QWidget):
             if self.output_directory is not None:
                 self.__prep_directories_for_save()
                 self.__extract_cubes(block=block)
-                self.__save_yaml_file()
-                show_info("Done")
-
-            self.update_status_label("Ready")
+                if block:
+                    self.__finish_save()
 
     def __prep_directories_for_save(self):
         self.yaml_filename = self.output_directory / "training.yaml"
@@ -511,11 +509,21 @@ class CurationWidget(QWidget):
                     break
         else:
 
-            @thread_worker(connect={"yielded": self.update_progress})
+            @thread_worker(
+                connect={
+                    "yielded": self.update_progress,
+                    "returned": lambda _: self.__finish_save(),
+                }
+            )
             def extract_cubes():
                 yield from self.extract_cubes()
 
             extract_cubes()
+
+    def __finish_save(self):
+        self.__save_yaml_file()
+        show_info("Done")
+        self.update_status_label("Ready")
 
     def is_data_extractable(self) -> bool:
         if (

--- a/tests/napari/test_curation.py
+++ b/tests/napari/test_curation.py
@@ -248,3 +248,30 @@ def test_show_info_called_on_empty_training_layer(
     )
     assert valid_curation_widget.check_training_data_exists()
     mock_info_notification.assert_called_once()
+
+
+def test_async_save_done_only_after_cubes_written(
+    valid_curation_widget, tmp_path, qtbot
+):
+    """
+    Regression test for the async save path: the "Done" notification and the
+    training.yaml file must only appear after the cubes have been written, not
+    immediately when the export worker is launched.
+    """
+    widget = valid_curation_widget
+    widget.output_directory = tmp_path
+
+    with patch("cellfinder.napari.curation.show_info") as show_info:
+        widget.save_training_data(prompt_for_directory=False, block=False)
+
+        # Worker has only just been launched: nothing should be saved yet.
+        assert show_info.call_args_list == []
+        assert not (tmp_path / "training.yaml").exists()
+
+        qtbot.waitUntil(
+            lambda: (tmp_path / "training.yaml").exists(), timeout=20000
+        )
+
+        show_info.assert_called_once_with("Done")
+        assert len(list((tmp_path / "cells").glob("*.tif"))) == 2
+        assert len(list((tmp_path / "non_cells").glob("*.tif"))) == 2


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

In the napari curation widget, clicking "Save training data" showed a "Done" popup immediately, before any cubes had been written to disk. The output folder appeared empty, so users assumed the export had finished and could delete the folder mid-write, causing errors. The async (non-blocking) save path launched the cube-extraction `thread_worker` and then synchronously wrote `training.yaml` and showed "Done", without waiting for the worker to finish.

**What does this PR do?**

It moves the YAML write, the "Done" notification, and the status-label reset into a single `__finish_save` helper, invoked synchronously for the `block=True` path and from the worker's `returned` signal for the async path, so "Done" appears only after all cubes are saved.

## References

Fixes #548.

## How has this PR been tested?

Added a regression test `test_async_save_done_only_after_cubes_written` in `tests/napari/test_curation.py` that drives the async path and asserts no files exist and "Done" has not been shown immediately after the call returns, then waits for the worker (`qtbot.waitUntil`) and confirms "Done" fires exactly once with two cell and two non-cell cubes written. 

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)