### PR TITLE
Pass cell metadata through napari.

### DIFF
--- a/cellfinder/napari/utils.py
+++ b/cellfinder/napari/utils.py
@@ -1,10 +1,19 @@
-from typing import List, Optional, Tuple
+from collections import defaultdict
+from functools import partial
+from typing import Any, List, Optional, Tuple
 
 import napari
 import napari.layers
 import numpy as np
 from brainglobe_utils.cells.cells import Cell
 from brainglobe_utils.qtpy.logo import header_widget
+
+EMPTY_VALUE = object()
+
+
+def empty_object_array(n):
+    """Returns an array of the given size filled with the empty sentinel."""
+    return np.full(n, EMPTY_VALUE, dtype=object)
 
 
 def html_label_widget(label: str, *, tag: str = "b") -> dict:
@@ -45,14 +54,23 @@ def add_classified_layers(
     unknown_name: str = "Rejected",
     cell_name: str = "Detected",
     scale: Optional[Tuple[float, float, float]] = None,
-) -> None:
+) -> tuple[napari.layers.Points, napari.layers.Points]:
     """
     Adds cell candidates as two separate point layers - unknowns and cells, to
     the napari viewer. Does not add any other cell types, only Cell.UNKNOWN
     and Cell.CELL from the list of cells.
     """
-    viewer.add_points(
+    cells_metadata, cells_metadata_defaults = cells_metadata_to_arrays(
+        points, Cell.CELL
+    )
+    non_cells_metadata, non_cells_metadata_defaults = cells_metadata_to_arrays(
+        points, Cell.UNKNOWN
+    )
+
+    layer_unk = viewer.add_points(
         cells_to_array(points, Cell.UNKNOWN, napari_order=True),
+        features=non_cells_metadata,
+        feature_defaults=non_cells_metadata_defaults,
         name=unknown_name,
         size=15,
         n_dimensional=True,
@@ -63,8 +81,10 @@ def add_classified_layers(
         metadata=dict(point_type=Cell.UNKNOWN),
         scale=scale,
     )
-    viewer.add_points(
+    layer_cells = viewer.add_points(
         cells_to_array(points, Cell.CELL, napari_order=True),
+        features=cells_metadata,
+        feature_defaults=cells_metadata_defaults,
         name=cell_name,
         size=15,
         n_dimensional=True,
@@ -74,6 +94,7 @@ def add_classified_layers(
         metadata=dict(point_type=Cell.CELL),
         scale=scale,
     )
+    return layer_cells, layer_unk
 
 
 def add_single_layer(
@@ -82,13 +103,16 @@ def add_single_layer(
     name: str,
     cell_type: int,
     scale: Optional[Tuple[float, float, float]] = None,
-) -> None:
+) -> napari.layers.Points:
     """
     Adds all cells of cell_type Cell.TYPE to a new point layer in the napari
     viewer, with given name.
     """
-    viewer.add_points(
+    metadata, metadata_defaults = cells_metadata_to_arrays(points, cell_type)
+    layer = viewer.add_points(
         cells_to_array(points, cell_type, napari_order=True),
+        features=metadata,
+        feature_defaults=metadata_defaults,
         name=name,
         size=15,
         n_dimensional=True,
@@ -99,6 +123,37 @@ def add_single_layer(
         metadata=dict(point_type=cell_type),
         scale=scale,
     )
+    return layer
+
+
+def cells_metadata_to_arrays(
+    cells: list[Cell], type: int
+) -> tuple[dict[Any, np.ndarray], dict[Any, object]]:
+    """
+    Given a list of cells, after filtering out any cells not of the `type`, it
+    returns a dictionary representing all the metadata of all the cells. This
+    can be passed to napari as features of the point layer.
+
+    The dictionary's keys are the union of all the keys of the metadata of all
+    the cells. Their values are each a np object array filled with the empty
+    sentinel, except for those cells who have values for the given key.
+
+    Napari will track this in the points layer, adjusting the size of the
+    arrays when new points are added/removed in the GUI. Via feature_defaults,
+    napari sets new points values to the sentinel value.
+    """
+    cells = [c for c in cells if c.type == type]
+
+    # any new metadata key we encounter, if we haven't seen it, we create an
+    # empty array filled with the sentinel. Only those cells who have values
+    # for a given key have a non-sentinel value
+    data: dict = defaultdict(partial(empty_object_array, len(cells)))
+    for i, cell in enumerate(cells):
+        for key, value in cell.metadata.items():
+            data[key][i] = value
+
+    defaults = {key: EMPTY_VALUE for key in data.keys()}
+    return data, defaults
 
 
 def cells_to_array(
@@ -130,9 +185,13 @@ def napari_array_to_cells(
     each point in the layer.
     """
     data = np.asarray(points.data)[:, brainglobe_order].tolist()
+    metadata_list = points.features.to_dict(orient="records")
 
     cells = []
-    for row in data:
-        cells.append(Cell(pos=row, cell_type=cell_type))
+    for i, row in enumerate(data):
+        # there may not be any metadata at all, then features is empty
+        metadata = metadata_list[i] if metadata_list else {}
+        metadata = {k: v for k, v in metadata.items() if v is not EMPTY_VALUE}
+        cells.append(Cell(pos=row, cell_type=cell_type, metadata=metadata))
 
     return cells

--- a/tests/napari/test_utils.py
+++ b/tests/napari/test_utils.py
@@ -3,6 +3,7 @@ from brainglobe_utils.cells.cells import Cell
 
 from cellfinder.napari.utils import (
     add_classified_layers,
+    add_single_layer,
     cells_to_array,
     html_label_widget,
     napari_array_to_cells,
@@ -15,8 +16,8 @@ def test_add_classified_layers(make_napari_viewer):
     cell_pos = [1, 2, 3]
     unknown_pos = [4, 5, 6]
     points = [
-        Cell(pos=cell_pos, cell_type=Cell.CELL),
-        Cell(pos=unknown_pos, cell_type=Cell.UNKNOWN),
+        Cell(pos=cell_pos, cell_type=Cell.CELL, metadata={"size": 12}),
+        Cell(pos=unknown_pos, cell_type=Cell.UNKNOWN, metadata={"radius": 3}),
     ]
     viewer = make_napari_viewer()
     n_layers = len(viewer.layers)
@@ -37,6 +38,8 @@ def test_add_classified_layers(make_napari_viewer):
     assert rej_layer is not None
     assert cell_layer.data is not None
     assert rej_layer.data is not None
+    assert cell_layer.features is not None
+    assert rej_layer.features is not None
 
     # check data added in correct column order
     # CELL types
@@ -58,9 +61,9 @@ def test_add_classified_layers(make_napari_viewer):
     assert np.all(rej_layer.data == rej_data)
 
     # get cells back from napari points
-    cells_again = napari_array_to_cells(cell_layer.data, cell_type=Cell.CELL)
+    cells_again = napari_array_to_cells(cell_layer, cell_type=Cell.CELL)
     cells_again.extend(
-        napari_array_to_cells(rej_layer.data, cell_type=Cell.UNKNOWN)
+        napari_array_to_cells(rej_layer, cell_type=Cell.UNKNOWN)
     )
     assert cells_again == points
 
@@ -89,6 +92,49 @@ def test_add_classified_layers_propagates_scale(make_napari_viewer):
 
     assert np.allclose(accepted.scale, scale)
     assert np.allclose(rejected.scale, scale)
+
+
+def test_add_single_layer(make_napari_viewer):
+    """Smoke test for add_single_layer utility"""
+    cell_pos = [1, 2, 3], [4, 5, 6]
+    # make sure that even if the metadata is different across points, it all
+    # comes back correct
+    points = [
+        Cell(pos=cell_pos[0], cell_type=Cell.CELL, metadata={"size": 12}),
+        Cell(pos=cell_pos[1], cell_type=Cell.CELL, metadata={"radius": 3}),
+    ]
+    viewer = make_napari_viewer()
+    n_layers = len(viewer.layers)
+    # adds a "detected" and a "rejected layer"
+    add_single_layer(
+        points,
+        viewer,
+        name="my_points",
+        cell_type=Cell.CELL,
+    )
+    assert len(viewer.layers) == n_layers + 1
+
+    # check name match
+    cell_layer = None
+    for layer in reversed(viewer.layers):
+        if layer.name == "my_points" and cell_layer is None:
+            cell_layer = layer
+    assert cell_layer is not None
+    assert cell_layer.data is not None
+    assert cell_layer.features is not None
+
+    # check data added in correct column order
+    cell_data = np.array(cell_pos)
+    assert np.all(
+        cells_to_array(points, Cell.CELL, napari_order=False) == cell_data
+    )
+    # convert to napari order and check it is in napari
+    cell_data = cell_data[:, napari_points_axis_order]
+    assert np.all(cell_layer.data == cell_data)
+
+    # get cells back from napari points
+    cells_again = napari_array_to_cells(cell_layer, cell_type=Cell.CELL)
+    assert cells_again == points
 
 
 def test_html_label_widget():


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Previously we added support for round-tripping cell metadata through Napari via https://github.com/brainglobe/brainglobe-napari-io/pull/102. However, within Cellfinder itself we also add cell layers and convert layers to `Cell`s. The code within cellfinder did not have support for round-tripping cell metadata.

**What does this PR do?**

This adds support for round-tripping the cell metadata, similar to that PR. Ideally this may all happen perhaps in brainglobe-utils? But for now it's not a lot of changes so I kept things simple and just added the fix here.

## References

https://github.com/brainglobe/brainglobe-napari-io/pull/102.

## How has this PR been tested?

Locally in typical use as well as added test.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
