### PR TITLE
Show number of cells already curated

### DIFF
--- a/cellfinder/napari/curation.py
+++ b/cellfinder/napari/curation.py
@@ -255,20 +255,27 @@ class CurationWidget(QWidget):
             self._set_normalization_n_sampling_planes
         )
         self.norm_sampling_box = box_norm
-        self.training_data_cell_choice, _ = add_combobox(
-            self.load_data_layout,
-            "Training data (cells)",
-            self.point_layer_names,
-            7,
-            callback=self.set_training_data_cell,
+        self.training_data_cell_choice, self.training_data_cell_label = (
+            add_combobox(
+                self.load_data_layout,
+                "Training data (cells, 0)",
+                self.point_layer_names,
+                7,
+                callback=self.set_training_data_cell,
+            )
         )
-        self.training_data_non_cell_choice, _ = add_combobox(
+        self._cell_label_update()
+        (
+            self.training_data_non_cell_choice,
+            self.training_data_non_cell_label,
+        ) = add_combobox(
             self.load_data_layout,
-            "Training_data (non_cells)",
+            "Training data (non-cells, 0)",
             self.point_layer_names,
             row=8,
             callback=self.set_training_data_non_cell,
         )
+        self._non_cell_label_update()
         self.mark_as_cell_button = add_button(
             "Mark as cell(s)",
             self.load_data_layout,
@@ -324,30 +331,66 @@ class CurationWidget(QWidget):
                 self.background_image_choice.currentText()
             ]
 
+    def _cell_label_update(self, *args, **kwargs) -> None:
+        layer = self.training_data_cell_layer
+        label = self.training_data_cell_label
+
+        count = "empty"
+        if layer and len(layer.data):
+            count = len(layer.data)
+        label.setText(f"Training data (cells, {count})")
+
+    def _non_cell_label_update(self, *args, **kwargs) -> None:
+        layer = self.training_data_non_cell_layer
+        label = self.training_data_non_cell_label
+
+        count = "empty"
+        if layer and len(layer.data):
+            count = len(layer.data)
+        label.setText(f"Training data (non-cells, {count})")
+
     def set_training_data_cell(self):
         """
         Set cell training data from current training data text box selection.
         """
-        if self.training_data_cell_choice.currentText() != "":
-            self.training_data_cell_layer = self.viewer.layers[
-                self.training_data_cell_choice.currentText()
-            ]
-            self.training_data_cell_layer.metadata["point_type"] = Cell.CELL
-            self.training_data_cell_layer.metadata["training_data"] = True
+        old_layer = self.training_data_cell_layer
+        if old_layer is not None:
+            old_layer.events.data.disconnect(self._cell_label_update)
+
+        name = self.training_data_cell_choice.currentText()
+        if name:
+            layer = self.viewer.layers[name]
+            self.training_data_cell_layer = layer
+            layer.metadata["point_type"] = Cell.CELL
+            layer.metadata["training_data"] = True
+
+            layer.events.data.connect(self._cell_label_update)
+        else:
+            self.training_data_cell_layer = None
+
+        self._cell_label_update()
 
     def set_training_data_non_cell(self):
         """
         Set non-cell training data from current training data text box
         selection.
         """
-        if self.training_data_non_cell_choice.currentText() != "":
-            self.training_data_non_cell_layer = self.viewer.layers[
-                self.training_data_non_cell_choice.currentText()
-            ]
-            self.training_data_non_cell_layer.metadata["point_type"] = (
-                Cell.UNKNOWN
-            )
-            self.training_data_non_cell_layer.metadata["training_data"] = True
+        old_layer = self.training_data_non_cell_layer
+        if old_layer is not None:
+            old_layer.events.data.disconnect(self._non_cell_label_update)
+
+        name = self.training_data_non_cell_choice.currentText()
+        if name:
+            layer = self.viewer.layers[name]
+            self.training_data_non_cell_layer = layer
+            layer.metadata["point_type"] = Cell.UNKNOWN
+            layer.metadata["training_data"] = True
+
+            layer.events.data.connect(self._non_cell_label_update)
+        else:
+            self.training_data_non_cell_layer = None
+
+        self._non_cell_label_update()
 
     def add_training_data(self):
         cell_name = "Training data (cells)"
@@ -367,11 +410,12 @@ class CurationWidget(QWidget):
             self._add_training_data_layers(cell_name, non_cell_name)
 
         if overwrite:
-            try:
-                self.viewer.layers.remove(cell_name)
-                self.viewer.layers.remove(non_cell_name)
-            except ValueError:
-                pass
+            if self.training_data_cell_layer:
+                self.viewer.layers.remove(self.training_data_cell_layer.name)
+            if self.training_data_non_cell_layer:
+                self.viewer.layers.remove(
+                    self.training_data_non_cell_layer.name
+                )
 
             self._add_training_data_layers(cell_name, non_cell_name)
 
@@ -387,7 +431,9 @@ class CurationWidget(QWidget):
             name=cell_name,
             metadata=dict(point_type=Cell.CELL, training_data=True),
         )
-        self.training_data_cell_choice.setCurrentText(cell_name)
+        self.training_data_cell_choice.setCurrentText(
+            self.training_data_cell_layer.name
+        )
 
         self.training_data_non_cell_layer = self.viewer.add_points(
             None,
@@ -400,7 +446,9 @@ class CurationWidget(QWidget):
             name=non_cell_name,
             metadata=dict(point_type=Cell.UNKNOWN, training_data=True),
         )
-        self.training_data_non_cell_choice.setCurrentText(non_cell_name)
+        self.training_data_non_cell_choice.setCurrentText(
+            self.training_data_non_cell_layer.name
+        )
 
     def mark_as_cell(self, viewer=None):
         self.mark_point_as_type("cell")

--- a/tests/napari/test_curation.py
+++ b/tests/napari/test_curation.py
@@ -297,3 +297,71 @@ def test_async_save_done_only_after_cubes_written(
         show_info.assert_called_once_with("Done")
         assert len(list((tmp_path / "cells").glob("*.tif"))) == 2
         assert len(list((tmp_path / "non_cells").glob("*.tif"))) == 2
+
+
+def test_curated_counts(curation_widget):
+    """
+    Checks that the current cell count is shown in the curation cell layer
+    label.
+    """
+    widget = curation_widget
+    widget.add_training_data()
+    viewer = widget.viewer
+
+    cell_layer = widget.training_data_cell_layer
+    cell_label = widget.training_data_cell_label
+    non_cell_layer = widget.training_data_non_cell_layer
+    non_cell_label = widget.training_data_non_cell_label
+
+    # nothing marked yet
+    assert cell_label.text() == "Training data (cells, empty)"
+    assert non_cell_label.text() == "Training data (non-cells, empty)"
+
+    # Add a points layer to select points from
+    points = Points(
+        np.array([[16, 17, 18], [13, 14, 15], [12, 33, 15]]),
+        name="selection_points",
+    )
+    # Adding the layer automatically selects it in the layer list
+    viewer.add_layer(points)
+
+    # Select the first point, and add as a cell
+    points.selected_data = [0]
+    curation_widget.mark_as_cell()
+    assert cell_label.text() == "Training data (cells, 1)"
+    assert non_cell_label.text() == "Training data (non-cells, empty)"
+
+    # Select the second point, and add as a non-cell
+    points.selected_data = [1]
+    curation_widget.mark_as_non_cell()
+    assert cell_label.text() == "Training data (cells, 1)"
+    assert non_cell_label.text() == "Training data (non-cells, 1)"
+
+    # Select the third point, and add as a cell
+    points.selected_data = [2]
+    curation_widget.mark_as_cell()
+    assert cell_label.text() == "Training data (cells, 2)"
+    assert non_cell_label.text() == "Training data (non-cells, 1)"
+
+    # change up the layers, both point to non-cells
+    widget.training_data_cell_choice.setCurrentText(non_cell_layer.name)
+    assert cell_label.text() == "Training data (cells, 1)"
+    assert non_cell_label.text() == "Training data (non-cells, 1)"
+
+    # now non-cells points to cells, they are flipped
+    widget.training_data_non_cell_choice.setCurrentText(cell_layer.name)
+    assert cell_label.text() == "Training data (cells, 1)"
+    assert non_cell_label.text() == "Training data (non-cells, 2)"
+
+    # now check deleting points reverts to empty
+    non_cell_layer.remove([0])
+    assert cell_label.text() == "Training data (cells, empty)"
+    assert non_cell_label.text() == "Training data (non-cells, 2)"
+
+    cell_layer.remove([0])
+    assert cell_label.text() == "Training data (cells, empty)"
+    assert non_cell_label.text() == "Training data (non-cells, 1)"
+
+    cell_layer.remove([0])
+    assert cell_label.text() == "Training data (cells, empty)"
+    assert non_cell_label.text() == "Training data (non-cells, empty)"


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

During cell curation, one typically targets a number of cells to curate. Currently there's no visual indicator show how many cells/non-cells have been labeled.

**What does this PR do?**

This adds a count showing the number of cells and non-cells labeled in the corresponding layers.

<img width="497" height="242" alt="image" src="https://github.com/user-attachments/assets/d6c59669-cd5b-45d5-b91c-b6b9a54b5bd9" />


## References

None.

## How has this PR been tested?

Locally and with new tests.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
