### PR TITLE
Fix test that failed due to reliance on randomness

### DIFF
--- a/tests/core/test_unit/test_classify/test_cube_gen.py
+++ b/tests/core/test_unit/test_classify/test_cube_gen.py
@@ -1257,8 +1257,18 @@ def _get_volume_with_stats(normalize):
         back_norm = back_mean, back_std
 
     volume = np.empty((20, 20, 30, 2), dtype=np.float32)
-    volume[..., 0] = np.random.normal(sig_mean, sig_std, (20, 20, 30))
-    volume[..., 1] = np.random.normal(back_mean, back_std, (20, 20, 30))
+
+    # alternate volume with +/- std so that whichever sub-cuboid we take from
+    # the volume, it'll always have the prescribed mean/std
+    ch0 = np.empty(20 * 20 * 30, dtype=np.float32)
+    ch0[0::2] = sig_mean - sig_std
+    ch0[1::2] = sig_mean + sig_std
+    ch1 = np.empty(20 * 20 * 30, dtype=np.float32)
+    ch1[0::2] = back_mean - back_std
+    ch1[1::2] = back_mean + back_std
+
+    volume[..., 0] = ch0.reshape((20, 20, 30))
+    volume[..., 1] = ch1.reshape((20, 20, 30))
 
     return (
         volume,
@@ -1288,8 +1298,8 @@ def _check_cube_normalization(
             # if normalized, it should be standard normal
             if normalize:
                 ex_mean, ex_std = 0, 1
-                lower_mean = -0.2
-                upper_mean = 0.2
+                lower_mean = -0.01
+                upper_mean = 0.01
 
             assert lower_mean <= mean.item() < upper_mean
             assert ex_std * 0.8 <= std.item() < ex_std * 1.2


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

To test that cube normalization worked, I had a test that created a volume using a normal distribution and then I tested that after normalization the mean was zero and std was 1, within some bounds. The problem is that this test failed in this unrelated PR https://github.com/brainglobe/cellfinder/actions/runs/27896437125/job/82548769409?pr=628. That's because when taking cuboids of the volume, their mean/std was out of the testing bounds simply due to randomness leading to test failure.

**What does this PR do?**

This creates the volume without relying on randomness, making it so that every cuboid should have similar mean/std. We do it by alternating the values around the mean by +/- std.

## References

https://github.com/brainglobe/cellfinder/actions/runs/27896437125/job/82548769409?pr=628

## How has this PR been tested?

The test works.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
