### PR TITLE
Expose augmentation params in napari and cli

### DIFF
--- a/cellfinder/core/classify/augment.py
+++ b/cellfinder/core/classify/augment.py
@@ -1,3 +1,4 @@
+import math
 from typing import Literal, Sequence
 
 import torch
@@ -8,7 +9,49 @@ from cellfinder.core.tools.tools import get_axis_reordering, random_bool
 
 DIM = Literal["x", "y", "z", "c"]
 AXIS = Literal["x", "y", "z"]
-RandRange = Sequence[float] | Sequence[tuple[float, float]] | None
+RandRangeSeq = Sequence[tuple[float, float]] | None
+RandRange = tuple[float, float] | None
+
+
+def interval_to_rand_range_3d(
+    a: float,
+    b: float,
+    min_val: float = float("-inf"),
+    max_val: float = float("inf"),
+) -> RandRangeSeq:
+    """
+    Converts an interval to a 3d interval accepted by `DataAugmentation`.
+    The interval is replicated 3 times so all 3 axes have the same interval.
+
+    The interval extent is forced to the specified min/max. If the interval
+    ends are misordered or they are the same, it returns None.
+    """
+    a = max(min_val, min(max_val, a))
+    b = max(min_val, min(max_val, b))
+    if math.isclose(a, b) or b < a:
+        return None
+    return [
+        (a, b),
+    ] * 3
+
+
+def interval_to_rand_range(
+    a: float,
+    b: float,
+    min_val: float = float("-inf"),
+    max_val: float = float("inf"),
+) -> RandRange:
+    """
+    Converts an interval to an interval accepted by `DataAugmentation`.
+
+    The interval extent is forced to the specified min/max. If the interval
+    ends are misordered or they are the same, it returns None.
+    """
+    a = max(min_val, min(max_val, a))
+    b = max(min_val, min(max_val, b))
+    if math.isclose(a, b) or b < a:
+        return None
+    return a, b
 
 
 class DataAugmentation:
@@ -63,33 +106,33 @@ class DataAugmentation:
     :param translate_range: The per-axis translation factor. If None there's no
         translation. Otherwise, it's a sequence of size 3 corresponding to the
         data axis in ``data_dim_order`` (channel axis is excluded). Each
-        element is either a float or a 2-tuple of floats indicating the
+        element is a 2-tuple of floats indicating the
         translation for that axis. Floats are in the ``[-1, 1]`` interval,
         where ``-1`` means negative translation by a full ``volume_size`` of
-        that axis and zero means no translation. A single float means there's
-        a ``augment_likelihood`` of the given axis to be translated by that
-        value. A 2-tuple of floats means there's a ``augment_likelihood`` of
-        the given axis to be translated to a random value in that interval.
+        that axis and zero means no translation. There's an
+        ``augment_likelihood`` of the given axis to be translated to a random
+        value in that interval.
     :param scale_range: The per-axis scaling factor. If None there's no
         scaling. Otherwise, it's a sequence of size 3 corresponding to the data
         axis in ``data_dim_order`` (channel axis is excluded). Each element is
-        either a float or a 2-tuple of floats indicating the scaling for
-        that axis. Floats are in the ``(0, inf)`` interval, where ``1`` means
-        unscaled. A single float means there's a ``augment_likelihood`` of the
-        given axis to be scaled by that value. A 2-tuple of floats means
-        there's a ``augment_likelihood`` of the given axis to be scaled to a
-        random value in that interval.
+        a 2-tuple of floats indicating the scaling for that axis. Floats are in
+        the ``(0, inf)`` interval, where ``1`` means unscaled. There's a
+        ``augment_likelihood`` of the given axis to be scaled to a random value
+        in that interval.
     :param rotate_range: The per-axis rotation factor in radians. If None
         there's no rotation. Otherwise, it's a sequence of size 3 corresponding
         to the data axis in ``data_dim_order`` (channel axis is excluded). Each
-        element is either a float or a 2-tuple of floats indicating the
-        rotation **around** that axis. Floats are in the ``[0, 2pi)`` interval,
-        where the value indicates a clockwise or counter-clockwise rotation
+        element is a 2-tuple of floats indicating the rotation **around** that
+        axis. Floats are in the ``[-360, 360]`` interval, where the value
+        indicates a clockwise or counter-clockwise rotation
         (depending on if it's x/y or z axis) in radians around that axis. And
-        where zero means no rotation. A single float means there's a
-        ``augment_likelihood`` of a rotation around the given axis by that
-        value. A 2-tuple of floats means there's an ``augment_likelihood`` of a
+        where zero means no rotation. There's an ``augment_likelihood`` of a
         rotation around the given axis by a random value in that interval.
+    :param intensity_range: The voxels multiplication factor. If None
+        it's the raw volume. Otherwise, it's a 2-tuple with the range of
+        floats to use to multiply the volume's voxels. Floats are
+        in the ``[0, inf)`` interval. There's an ``augment_likelihood``
+        of multiplying by a random value in that interval.
     """
 
     DIM_ORDER = "c", "y", "x", "z"
@@ -135,25 +178,20 @@ class DataAugmentation:
     dimensions of the input data (excluding the channel dimension)..
     """
 
-    _asked_affine: bool
-    """If the any of the affine transformations were requested."""
-
     _is_isotropic: bool
     """
     Whether the input data is isotropic (excluding the channel dimension).
     """
 
-    _do_affine: bool
-    """
-    After randomization, if we should do affine transformation on the next
-    augmentation call based on the random value.
-    """
+    augment_likelihood: float = 0
+    """The likelihood to use for each augmentation randomization. See above."""
 
-    _affine: RandAffine
+    _rotate_trans: RandAffine = None
     """The RandAffine used to do the affine transformations."""
 
-    augment_likelihood: float
-    """The likelihood to use for each augmentation randomization. See above."""
+    _translate_trans: RandAffine = None
+
+    _scale_trans: RandAffine = None
 
     _flippable_axis: Sequence[int]
     """
@@ -161,11 +199,9 @@ class DataAugmentation:
     randomly flipped.
     """
 
-    _axes_to_flip: Sequence[int]
-    """
-    After randomization, which of the axes to actually flip in the next
-    augmentation call.
-    """
+    _intensity_range: RandRange = None
+
+    _augmentations_to_do: set[str]
 
     def __init__(
         self,
@@ -173,14 +209,12 @@ class DataAugmentation:
         data_dim_order: tuple[DIM, DIM, DIM, DIM],
         augment_likelihood: float,
         flippable_axis: Sequence[int] = (),
-        translate_range: RandRange = None,
-        scale_range: RandRange = None,
-        rotate_range: RandRange = None,
+        translate_range: RandRangeSeq = None,
+        scale_range: RandRangeSeq = None,
+        rotate_range: RandRangeSeq = None,
+        intensity_range: RandRange = None,
     ):
         volume_values = list(volume_size.values())
-        self._asked_affine = bool(
-            translate_range or scale_range or rotate_range
-        )
         self._is_isotropic = max(volume_values) == min(volume_values)
         self._isotropic_volume_size = (max(volume_values),) * 3
 
@@ -192,22 +226,36 @@ class DataAugmentation:
         self._compute_data_reordering(data_dim_order)
 
         # do prob = 1 because we decide when to apply the affine later
-        self._affine = RandAffine(
-            prob=1,
-            rotate_range=self._fix_rotate_range(rotate_range),
-            shear_range=None,
-            translate_range=self._fix_translate_range(translate_range),
-            scale_range=self._fix_scale_range(scale_range),
-            cache_grid=True,
-            spatial_size=self._isotropic_volume_size,
-            lazy=False,
-        )
+        if rotate_range is not None:
+            self._rotate_trans = RandAffine(
+                prob=1,
+                rotate_range=self._fix_rotate_range(rotate_range),
+                cache_grid=True,
+                spatial_size=self._isotropic_volume_size,
+                lazy=False,
+            )
+        if translate_range is not None:
+            self._translate_trans = RandAffine(
+                prob=1,
+                translate_range=self._fix_translate_range(translate_range),
+                cache_grid=True,
+                spatial_size=self._isotropic_volume_size,
+                lazy=False,
+            )
+        if scale_range is not None:
+            self._scale_trans = RandAffine(
+                prob=1,
+                scale_range=self._fix_scale_range(scale_range),
+                cache_grid=True,
+                spatial_size=self._isotropic_volume_size,
+                lazy=False,
+            )
 
         self._flippable_axis = self._fix_flippable_axis(flippable_axis)
+        self._intensity_range = intensity_range
         self.augment_likelihood = augment_likelihood
 
-        self._axes_to_flip = []
-        self._do_affine = False
+        self._augmentations_to_do = set()
 
     def _compute_data_reordering(
         self, data_dim_order: tuple[DIM, DIM, DIM, DIM]
@@ -235,9 +283,9 @@ class DataAugmentation:
     ) -> Sequence[int]:
         """
         Users provide the axis in ``data_dim_order``, but during augmentation
-        we expect the data to have been re-ordered to ``DIM_ORDER``. So we
+        we expect the data to have been re-ordered to ``AXIS_ORDER``. So we
         transform and return the input ``flippable_axis`` from
-        ``data_dim_order`` to ``DIM_ORDER`` so it can be directly used.
+        ``data_dim_order`` to ``AXIS_ORDER`` so it can be directly used.
         """
         if not flippable_axis:
             return flippable_axis
@@ -250,27 +298,26 @@ class DataAugmentation:
             fixed_axis.append(self.AXIS_ORDER.index(ax))
         return fixed_axis
 
-    def _fix_rotate_range(self, rotate_range: RandRange) -> RandRange:
+    def _fix_rotate_range(self, rotate_range: RandRangeSeq) -> RandRangeSeq:
         """
         Users provide the axis in ``data_dim_order``, but during augmentation
         we expect the data to have been re-ordered to ``DIM_ORDER``. So we
         re-order and return the input ``rotate_range`` from
         ``data_dim_order`` to ``DIM_ORDER`` so it can be directly used.
 
+        Similarly, we convert the input from degrees to radians.
+
         ``test_monai_rotate_input`` verifies the monai input as doing
         rotations. However, clockwise or anti-clockwise rotations occur in
         MONAI depending on whether we rotate around x/y or z axis, which won't
         matter for augmentation.
         """
-        if rotate_range is None:
-            return None
         if len(rotate_range) != 3:
             raise ValueError("Must specify rotate value for each dimension")
 
         rotate_range = list(rotate_range)
-        for i, val in enumerate(rotate_range):
-            if not isinstance(val, Sequence):
-                rotate_range[i] = val, val
+        for i, (s, e) in enumerate(rotate_range):
+            rotate_range[i] = s / 180 * math.pi, e / 180 * math.pi
 
         if self._input_axis_order == self.AXIS_ORDER:
             return rotate_range
@@ -281,7 +328,9 @@ class DataAugmentation:
             fixed_range[new_i] = rotate_range[i]
         return fixed_range
 
-    def _fix_translate_range(self, translate_range: RandRange) -> RandRange:
+    def _fix_translate_range(
+        self, translate_range: RandRangeSeq
+    ) -> RandRangeSeq:
         """
         Users provide the axis in ``data_dim_order``, but during augmentation
         we expect the data to have been re-ordered to ``DIM_ORDER``. So we
@@ -291,8 +340,6 @@ class DataAugmentation:
         We also transform the range from fraction to (negative) pixels as
         expected by monai. This is verified by ``test_monai_translate_input``.
         """
-        if translate_range is None:
-            return None
         if len(translate_range) != 3:
             raise ValueError("Must specify translate value for each dimension")
 
@@ -302,12 +349,9 @@ class DataAugmentation:
         ):
             # we expect the values as fraction of the size of the volume in
             # the given dim. monai expects it as pixel offsets so we need
-            # to multiply by dim size. Also, monai does negative translation
-            if isinstance(val, Sequence):
-                # interval order seems irrelevant in monai
-                translate_range[i] = -val[0] * size, -val[1] * size
-            else:
-                translate_range[i] = -val * size, -val * size
+            # to multiply by dim size. Also, monai does negative translation.
+            # interval order seems irrelevant in monai
+            translate_range[i] = -val[0] * size, -val[1] * size
 
         if self._input_axis_order == self.AXIS_ORDER:
             return translate_range
@@ -318,7 +362,7 @@ class DataAugmentation:
             fixed_range[new_i] = translate_range[i]
         return fixed_range
 
-    def _fix_scale_range(self, scale_range: RandRange) -> RandRange:
+    def _fix_scale_range(self, scale_range: RandRangeSeq) -> RandRangeSeq:
         """
         Users provide the axis in ``data_dim_order``, but during augmentation
         we expect the data to have been re-ordered to ``DIM_ORDER``. So we
@@ -330,21 +374,16 @@ class DataAugmentation:
         by monai. Yes the interval is nonsensical and yes, this is what monai
         expects. We verify this in ``test_monai_scale_input``.
         """
-        if scale_range is None:
-            return None
         if len(scale_range) != 3:
             raise ValueError("Must specify scale value for each dimension")
 
         scale_range = list(scale_range)
         for i, val in enumerate(scale_range):
             # we get scale values where 1 means original size. monai
-            # expects values around 0, where 0 means original size
-            if isinstance(val, Sequence):
-                # interval order seems irrelevant so (inf, -1) would become
-                # (-1, inf) in monai
-                scale_range[i] = 1 / val[0] - 1, 1 / val[1] - 1
-            else:
-                scale_range[i] = 1 / val - 1, 1 / val - 1
+            # expects values around 0, where 0 means original size.
+            # interval order seems irrelevant so (inf, -1) would become
+            # (-1, inf) in monai
+            scale_range[i] = 1 / val[0] - 1, 1 / val[1] - 1
 
         if self._input_axis_order == self.AXIS_ORDER:
             return scale_range
@@ -363,27 +402,23 @@ class DataAugmentation:
         be called with data, which will be augmented. Otherwise, it's False
         and if the augmentor is called it will return the original data.
         """
-        self._do_affine = False
-        if self._asked_affine:
-            self._do_affine = random_bool(likelihood=self.augment_likelihood)
-        self._update_flip_parameters()
+        prob = self.augment_likelihood
+        augmentations = self._augmentations_to_do = set()
 
-        return bool(self._do_affine or self._axes_to_flip)
+        for aug in ["rotate", "translate", "scale"]:
+            if getattr(self, f"_{aug}_trans") is not None and random_bool(
+                likelihood=prob
+            ):
+                augmentations.add(aug)
 
-    def _update_flip_parameters(self) -> None:
-        """
-        Evaluates random variables to decide which of the requested axes to
-        flip in the next augmentation call, if any.
-        """
-        flippable_axis = self._flippable_axis
-        if not flippable_axis:
-            return
+        for ax in self._flippable_axis:
+            if random_bool(likelihood=prob):
+                augmentations.add(f"flip_{ax}")
 
-        axes_to_flip = self._axes_to_flip = []
-        for axis in flippable_axis:
-            if random_bool(likelihood=self.augment_likelihood):
-                # add 1 because of initial channel dim
-                axes_to_flip.append(axis + 1)
+        if self._intensity_range is not None and random_bool(likelihood=prob):
+            augmentations.add("intensity")
+
+        return bool(augmentations)
 
     def rescale_to_isotropic(self, data: torch.Tensor) -> torch.Tensor:
         """
@@ -425,31 +460,71 @@ class DataAugmentation:
         data = data.squeeze(0)
         return data
 
-    def apply_affine(self, data: torch.Tensor) -> torch.Tensor:
-        """
-        Applies and returns the affine transformed data if it was requested and
-        if the randomization via ``update_parameters`` requires it. Otherwise,
-        it returns the data unchanged.
+    @property
+    def needs_isotropic(self) -> bool:
+        return bool(
+            {"rotate", "translate", "scale"} & self._augmentations_to_do
+        )
 
-        Data must be isotropic and in ``DIM_ORDER``.
+    def apply_rotate(self, data: torch.Tensor) -> torch.Tensor:
         """
-        if not self._do_affine:
+        Returns input data, rotated, if ``update_parameters`` required it.
+        Otherwise, it returns the data unchanged. Data must be isotropic in
+        ``DIM_ORDER``.
+        """
+        if "rotate" not in self._augmentations_to_do:
             return data
 
-        return self._affine(data, padding_mode="border")
+        return self._rotate_trans(data, padding_mode="border")
 
-    def flip_axis(self, data: torch.Tensor) -> torch.Tensor:
+    def apply_translate(self, data: torch.Tensor) -> torch.Tensor:
         """
-        Applies and returns axes flipped data if it was requested and
-        if the randomization via ``update_parameters`` requires it. Otherwise,
-        it returns the data unchanged.
-
-        Data must be in ``DIM_ORDER``.
+        Returns input data, translated, if ``update_parameters`` required it.
+        Otherwise, it returns the data unchanged. Data must be isotropic in
+        ``DIM_ORDER``.
         """
-        if not self._axes_to_flip:
+        if "translate" not in self._augmentations_to_do:
             return data
 
-        return torch.flip(data, self._axes_to_flip)
+        return self._translate_trans(data, padding_mode="border")
+
+    def apply_scale(self, data: torch.Tensor) -> torch.Tensor:
+        """
+        Returns input data, scaled, if ``update_parameters`` required it.
+        Otherwise, it returns the data unchanged. Data must be isotropic in
+        ``DIM_ORDER``.
+        """
+        if "scale" not in self._augmentations_to_do:
+            return data
+
+        return self._scale_trans(data, padding_mode="border")
+
+    def flip_axis(self, data: torch.Tensor, axis: int) -> torch.Tensor:
+        """
+        Returns input data, flipped along ``axis``, if ``update_parameters``
+        required it. Otherwise, it returns the data unchanged. Data must be
+        in ``DIM_ORDER``.
+        """
+        if f"flip_{axis}" not in self._augmentations_to_do:
+            return data
+
+        # add one to account for channel dim, which is first axis
+        return torch.flip(data, (axis + 1,))
+
+    def apply_intensity(self, data: torch.Tensor) -> torch.Tensor:
+        """
+        Returns input data, multiplied by an intensity, if
+        ``update_parameters`` required it. Otherwise, it returns the data
+        unchanged. Data must be in ``DIM_ORDER``.
+        """
+        if "intensity" not in self._augmentations_to_do:
+            return data
+
+        s, e = self._intensity_range
+        val = torch.rand(1)[0].item()
+        factor = (e - s) * val + s
+
+        return data * factor
 
     def __call__(self, data: torch.Tensor) -> torch.Tensor:
         if len(data.shape) != 4:
@@ -468,15 +543,19 @@ class DataAugmentation:
             )
 
         # if we do affine, it must be isotropic
-        if self._do_affine:
+        if self.needs_isotropic:
             data = self.rescale_to_isotropic(data)
 
-        # apply affine and axes flipping based on last update_parameters
-        data = self.apply_affine(data)
-        data = self.flip_axis(data)
+        # these only do the augmentation if update_parameters set it
+        data = self.apply_rotate(data)
+        data = self.apply_translate(data)
+        data = self.apply_scale(data)
+        data = self.apply_intensity(data)
+        for i in range(3):
+            data = self.flip_axis(data, i)
 
         # undo isotropism
-        if self._do_affine:
+        if self.needs_isotropic:
             data = self.rescale_to_original(data)
 
         # make sure it's in data_dim_order

--- a/cellfinder/core/classify/cube_generator.py
+++ b/cellfinder/core/classify/cube_generator.py
@@ -14,7 +14,11 @@ from torch.multiprocessing import Queue
 from torch.utils.data import Dataset, Sampler, get_worker_info
 
 from cellfinder.core import types
-from cellfinder.core.classify.augment import DataAugmentation
+from cellfinder.core.classify.augment import (
+    DataAugmentation,
+    RandRange,
+    RandRangeSeq,
+)
 from cellfinder.core.tools.threading import (
     EOFSignal,
     ExecutionFailure,
@@ -28,7 +32,6 @@ from cellfinder.core.tools.tools import (
 
 AXIS = Literal["x", "y", "z"]
 DIM = Literal[AXIS, "c"]
-RandRange = Sequence[float] | Sequence[tuple[float, float]] | None
 
 
 _point_ax_map = {"x": 0, "y": 1, "z": 2}
@@ -592,21 +595,26 @@ class CuboidDatasetBase(Dataset):
         potentially flip around its center during augmentation, if any, with
         probability ``augment_likelihood``. See ``DataAugmentation`` class for
         full details.
-    :param rotate_range: A sequence of floats or sequence of 2-tuples with the
-        radian angle or range of angles to rotate the data in the corresponding
+    :param rotate_range: A sequence of 2-tuples with the
+        range of degree angles to rotate the data in the corresponding
         ``axis_order`` axis during augmentation with probability
         ``augment_likelihood``. Where zero means no rotation. Or ``None`` if
         there's no rotation to any axis. See ``DataAugmentation`` class for
         full details.
-    :param translate_range: A sequence of floats or sequence of 2-tuples with
-        the fractional distance or range of distance to translate the data
+    :param translate_range: A sequence of 2-tuples with
+        the fractional range of distance to translate the data
         during augmentation with probability ``augment_likelihood``. Where zero
         means no translation.  Or `None` if there's no translation to any axis.
         See ``DataAugmentation`` class for full details.
-    :param scale_range: A sequence of floats or sequence of 2-tuples with
-        the amount or range of amount to scale the data during augmentation
+    :param scale_range: A sequence of 2-tuples with
+        the range of amount to scale the data during augmentation
         with probability ``augment_likelihood``. Where ``1`` means no scaling.
         Or `None` if there's no scaling to any axis. See ``DataAugmentation``
+        class for full details.
+    :param intensity_range: A 2-tuple with the range of the voxels
+        multiplication factor by which to multiply the data during augmentation
+        with probability ``augment_likelihood``. Where ``1`` means raw data.
+        Or `None` if there's no multiplication. See ``DataAugmentation``
         class for full details.
     """
 
@@ -663,9 +671,10 @@ class CuboidDatasetBase(Dataset):
         augment: bool = False,
         augment_likelihood: float = 0.9,
         flippable_axis: Sequence[int] = (0, 1, 2),
-        rotate_range: RandRange = (math.pi / 4,) * 3,
-        translate_range: RandRange = (0.05,) * 3,
-        scale_range: RandRange = ((0.6, 1.4),) * 3,
+        rotate_range: RandRangeSeq = ((-1, 1),) * 3,
+        translate_range: RandRangeSeq = ((-0.05, 0.05),) * 3,
+        scale_range: RandRangeSeq = None,
+        intensity_range: RandRange = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -735,6 +744,7 @@ class CuboidDatasetBase(Dataset):
                 translate_range,
                 scale_range,
                 rotate_range,
+                intensity_range,
             )
 
         if src_image_data is not None:

--- a/cellfinder/core/train/train_yaml.py
+++ b/cellfinder/core/train/train_yaml.py
@@ -39,6 +39,12 @@ from torch.utils.data import DataLoader
 
 import cellfinder.core as package_for_log
 from cellfinder.core import logger
+from cellfinder.core.classify.augment import (
+    RandRange,
+    RandRangeSeq,
+    interval_to_rand_range,
+    interval_to_rand_range_3d,
+)
 from cellfinder.core.classify.cube_generator import (
     CuboidBatchSampler,
     CuboidTiffDataset,
@@ -235,9 +241,69 @@ def training_parse():
         dest="augment_likelihood",
         type=check_positive_float,
         default=0.9,
-        help="Value `[0, 1]` with the probability of a data item being "
-        "augmented. I.e. `0.9` means 90%% of the data will have been "
-        "augmented.",
+        help="A value in [0, 1] with the probability to augment with each "
+        "transformation. Each transformation of each data sample is "
+        "independently sampled with this probability.",
+    )
+    training_parser.add_argument(
+        "--flippable-axis",
+        dest="flippable_axis",
+        nargs="*",
+        default=(0, 1, 2),
+        type=int,
+        help="A list of axes to potentially mirror around its center during "
+        "augmentation. Values corresponds to the z, y, and x axes. "
+        "E.g. if [0, 2] and `augment_likelihood` is 0.3, then axes 0 (z) "
+        "and 2 (x) have each independently a 30%% chance of being flipped "
+        "around their centers.",
+    )
+    training_parser.add_argument(
+        "--rotate-range",
+        dest="rotate_range",
+        nargs=2,
+        default=(-1, 1),
+        type=float,
+        help="The interval we sample during augmentation for each data item to"
+        " get a rotation value to rotate around the center of the sample in "
+        "the x, y, and z axes (by the same value). If the range start and "
+        "end is the same, no rotation is performed. Valid interval is "
+        "`[-360, 360]` degrees.",
+    )
+    training_parser.add_argument(
+        "--translate-range",
+        dest="translate_range",
+        nargs=2,
+        default=(-0.05, 0.05),
+        type=float,
+        help="The interval we sample during augmentation for each data item to"
+        " get a translation value to translate the sample along the x, y, "
+        "and z axes (by the same value). If the range start and end is the "
+        "same, no translation is performed. Meaningful interval is "
+        "`[-1, 1]`, where `0` means none and `1` means translate by a full "
+        "sample size positively.",
+    )
+    training_parser.add_argument(
+        "--scale-range",
+        dest="scale_range",
+        nargs=2,
+        default=(1, 1),
+        type=float,
+        help="The interval we sample during augmentation for each data item to"
+        " get a scaling value to scale the sample from its center in "
+        "the x, y, and z axes (by the same value). If the scale start and "
+        "end is the same, no scaling is performed. Valid interval is "
+        "`(0, inf]`, where `1` is the original scale.",
+    )
+    training_parser.add_argument(
+        "--intensity-range",
+        dest="intensity_range",
+        nargs=2,
+        default=(1, 1),
+        type=float,
+        help="The interval we sample during augmentation for each data item to"
+        " get a multiplication factor to multiply the sample voxels. If the "
+        "range start and end is the same, no multiplication is performed. "
+        "Valid interval is `(0, inf]`, where `1` is the original intensity.",
     )
     training_parser.add_argument(
         "--save-weights",
@@ -386,8 +452,8 @@ def cli():
 
     output_dir = Path(args.output_dir)
     run(
-        output_dir,
-        args.yaml_file,
+        output_dir=output_dir,
+        yaml_file=args.yaml_file,
         n_free_cpus=args.n_free_cpus,
         trained_model=args.trained_model,
         model_weights=args.model_weights,
@@ -409,6 +475,17 @@ def cli():
         lr_schedule=args.lr_schedule,
         lr_multiplier=args.lr_multiplier,
         normalize_channels=args.normalize_channels,
+        flippable_axis=list(set(args.flippable_axis) & {0, 1, 2}),
+        rotate_range=interval_to_rand_range_3d(
+            *args.rotate_range, min_val=-360, max_val=360
+        ),
+        translate_range=interval_to_rand_range_3d(
+            *args.translate_range, min_val=-1, max_val=1
+        ),
+        scale_range=interval_to_rand_range_3d(*args.scale_range, min_val=0),
+        intensity_range=interval_to_rand_range(
+            *args.intensity_range, min_val=0
+        ),
     )
 
 
@@ -422,6 +499,11 @@ def get_dataloader(
     augment: bool,
     augment_likelihood: float,
     normalize_channels: bool,
+    flippable_axis: Sequence[int] = (),
+    rotate_range: RandRangeSeq = None,
+    translate_range: RandRangeSeq = None,
+    scale_range: RandRangeSeq = None,
+    intensity_range: RandRange = None,
 ) -> tuple[DataLoader, CuboidTiffDataset]:
     points_filenames = [f[0] for f in filenames]
 
@@ -448,6 +530,11 @@ def get_dataloader(
         target_output="label",
         augment=augment,
         augment_likelihood=augment_likelihood,
+        flippable_axis=flippable_axis,
+        rotate_range=rotate_range,
+        translate_range=translate_range,
+        scale_range=scale_range,
+        intensity_range=intensity_range,
     )
     # we use our own sampler so we can control the ordering
     sampler = CuboidBatchSampler(
@@ -490,6 +577,11 @@ def run(
     lr_multiplier: float = 0.1,
     augment_likelihood: float = 0.9,
     normalize_channels: bool = False,
+    flippable_axis: Sequence[int] = (0, 1, 2),
+    rotate_range: RandRangeSeq = ((-1, 1),) * 3,
+    translate_range: RandRangeSeq = (-0.05, 0.05),
+    scale_range: RandRangeSeq = None,
+    intensity_range: RandRange = None,
 ):
     start_time = datetime.now()
 
@@ -559,6 +651,12 @@ def run(
         validation_dataset = None
         base_checkpoint_file_name = "-epoch.{epoch:02d}"
 
+    logger.info(
+        f"Augmenting = {not no_augment}. Probability = {augment_likelihood}. "
+        f"Flippable axes = {flippable_axis}. Rotation range = {rotate_range}. "
+        f"Translation range = {translate_range}. Scale range = {scale_range}. "
+        f"Intensity range = {intensity_range}."
+    )
     training_data_loader, training_dataset = get_dataloader(
         cells_train,
         filenames_train,
@@ -569,6 +667,11 @@ def run(
         augment=not no_augment,
         augment_likelihood=augment_likelihood,
         normalize_channels=normalize_channels,
+        flippable_axis=flippable_axis,
+        rotate_range=rotate_range,
+        translate_range=translate_range,
+        scale_range=scale_range,
+        intensity_range=intensity_range,
     )
     callbacks = []
 

--- a/cellfinder/napari/train/train.py
+++ b/cellfinder/napari/train/train.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Optional
+from typing import Literal, Optional
 
 from magicgui import magicgui
 from magicgui.widgets import FunctionGui, PushButton
@@ -58,17 +58,23 @@ def training_widget() -> FunctionGui:
         pretrained_model: str,
         training_options: dict,
         continue_training: bool,
-        augment: bool,
-        normalize_channels: bool,
-        tensorboard: bool,
-        save_checkpoints: bool,
-        save_progress: bool,
         epochs: int,
+        batch_size: int,
+        test_fraction: float,
+        normalize_channels: bool,
         learning_rate: float,
         lr_schedule: list[int],
         lr_multiplier: float,
-        batch_size: int,
-        test_fraction: float,
+        augment: bool,
+        augment_likelihood: float,
+        flippable_axis: list[Literal[0, 1, 2]],
+        rotate_range: tuple[float, float],
+        translate_range: tuple[float, float],
+        scale_range: tuple[float, float],
+        intensity_range: tuple[float, float],
+        tensorboard: bool,
+        save_checkpoints: bool,
+        save_progress: bool,
         misc_options: dict,
         number_of_free_cpus: int,
         reset_button: PushButton,
@@ -94,21 +100,17 @@ def training_widget() -> FunctionGui:
             Continue training from an existing trained model
             If no trained model or model weights are specified,
             this will continue from the pretrained model
-        augment : bool
-            Augment the training data to improve generalisation
+        epochs : int
+            Number of training epochs
+            (How many times to use each training data point)
+        batch_size : int
+            Training batch size
+        test_fraction : float
+            Fraction of training data to use for validation
         normalize_channels : bool
             Whether to normalize the cubes by the mean/std of their origin
             dataset. If True, the yaml files must include the mean/std of
             the origin dataset.
-        tensorboard : bool
-            Log to output_directory/tensorboard
-        save_checkpoints : bool
-            Store the model at intermediate points during training
-        save_progress : bool
-            Save training progress to a .csv file
-        epochs : int
-            Number of training epochs
-            (How many times to use each training data point)
         learning_rate : float
             Learning rate for training the model
         lr_schedule : list of ints
@@ -120,10 +122,48 @@ def training_widget() -> FunctionGui:
         lr_multiplier : float
             The multiplier by which to multiply the previous learning rate
             at the epochs listed in `lr_schedule`.
-        batch_size : int
-            Training batch size
-        test_fraction : float
-            Fraction of training data to use for validation
+        augment : bool
+            Augment the training data to improve generalisation
+        augment_likelihood: float
+            A value in [0, 1] with the probability to augment with each
+            transformation. Each transformation of each data sample is
+            independently sampled with this probability.
+        flippable_axis: list of axes indices
+            A list of axes to potentially mirror around its center during
+            augmentation. Values corresponds to the z, y, and x axes.
+            E.g. if [0, 2] and `augment_likelihood` is 0.3, then axes 0 (z)
+            and 2 (x) have each independently a 30% chance of being flipped
+            around their centers.
+        rotate_range: tuple of floats
+            The interval we sample during augmentation for each data item to
+            get a rotation value to rotate around the center of the sample in
+            the x, y, and z axes (by the same value). If the range start and
+            end is the same, no rotation is performed. Valid interval is
+            `[-360, 360]` degrees.
+        translate_range: tuple of floats
+            The interval we sample during augmentation for each data item to
+            get a translation value to translate the sample along the x, y,
+            and z axes (by the same value). If the range start and end is the
+            same, no translation is performed. Meaningful interval is
+            `[-1, 1]`, where `0` means none and `1` means translate by a full
+            sample size positively.
+        scale_range: tuple of floats
+            The interval we sample during augmentation for each data item to
+            get a scaling value to scale the sample from its center in
+            the x, y, and z axes (by the same value). If the scale start and
+            end is the same, no scaling is performed. Valid interval is
+            `(0, inf]`, where `1` is the original scale.
+        intensity_range: tuple of floats
+            The interval we sample during augmentation for each data item to
+            get a multiplication factor to multiply the sample voxels. If the
+            range start and end is the same, no multiplication is performed.
+            Valid interval is `(0, inf]`, where `1` is the original intensity.
+        tensorboard : bool
+            Log to output_directory/tensorboard
+        save_checkpoints : bool
+            Store the model at intermediate points during training
+        save_progress : bool
+            Save training progress to a .csv file
         number_of_free_cpus : int
             How many CPU cores to leave free
         reset_button : PushButton
@@ -154,6 +194,12 @@ def training_widget() -> FunctionGui:
             lr_schedule,
             lr_multiplier,
             normalize_channels,
+            augment_likelihood,
+            flippable_axis,
+            rotate_range,
+            translate_range,
+            scale_range,
+            intensity_range,
         )
 
         misc_training_inputs = MiscTrainingInputs(number_of_free_cpus)

--- a/cellfinder/napari/train/train_containers.py
+++ b/cellfinder/napari/train/train_containers.py
@@ -1,9 +1,13 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
 
 from magicgui.types import FileDialogMode
 
+from cellfinder.core.classify.augment import (
+    interval_to_rand_range,
+    interval_to_rand_range_3d,
+)
 from cellfinder.core.download.download import model_filenames
 from cellfinder.core.train.train_yaml import models
 from cellfinder.napari.input_container import InputContainer
@@ -84,6 +88,12 @@ class OptionalTrainingInputs(InputContainer):
     lr_schedule: list[int] | tuple[int, ...] = ()
     lr_multiplier: float = 0.1
     normalize_channels: bool = False
+    augment_likelihood: float = 0.9
+    flippable_axis: list[int] = field(default_factory=lambda: [0, 1, 2])
+    rotate_range: tuple[float, float] = -1, 1
+    translate_range: tuple[float, float] = -0.05, 0.05
+    scale_range: tuple[float, float] = 1, 1
+    intensity_range: tuple[float, float] = 1, 1
 
     def as_core_arguments(self) -> dict:
         arguments = super().as_core_arguments()
@@ -91,12 +101,19 @@ class OptionalTrainingInputs(InputContainer):
         arguments["no_save_checkpoints"] = not arguments.pop(
             "save_checkpoints"
         )
+        arguments["flippable_axis"] = list(set(arguments["flippable_axis"]))
+        for arg in ("rotate_range", "translate_range", "scale_range"):
+            arguments[arg] = interval_to_rand_range_3d(*arguments[arg])
+        arguments["intensity_range"] = interval_to_rand_range(
+            *arguments["intensity_range"]
+        )
+
         return arguments
 
     @classmethod
     def widget_representation(cls) -> dict:
         return dict(
-            training_options=html_label_widget("Training (optional)"),
+            training_options=html_label_widget("Training options"),
             continue_training=cls._custom_widget("continue_training"),
             augment=cls._custom_widget("augment"),
             tensorboard=cls._custom_widget("tensorboard"),
@@ -115,6 +132,26 @@ class OptionalTrainingInputs(InputContainer):
                 "lr_multiplier", custom_label="LR multiplier"
             ),
             normalize_channels=cls._custom_widget("normalize_channels"),
+            augment_likelihood=cls._custom_widget(
+                "augment_likelihood", step=0.01, min=0.00, max=1
+            ),
+            flippable_axis=cls._custom_widget("flippable_axis"),
+            rotate_range=cls._custom_widget(
+                "rotate_range",
+                options={"step": 1, "min": -360, "max": 360},
+            ),
+            translate_range=cls._custom_widget(
+                "translate_range",
+                options={"step": 0.01, "min": -1, "max": 1},
+            ),
+            scale_range=cls._custom_widget(
+                "scale_range",
+                options={"step": 0.01, "min": 0.00, "max": 100},
+            ),
+            intensity_range=cls._custom_widget(
+                "intensity_range",
+                options={"step": 0.01, "min": 0.00, "max": 1000},
+            ),
         )
 
 

--- a/tests/core/test_integration/test_train.py
+++ b/tests/core/test_integration/test_train.py
@@ -1,4 +1,5 @@
 import os
+from unittest.mock import patch
 
 import pytest
 from pytest_mock.plugin import MockerFixture
@@ -12,6 +13,96 @@ cell_cubes = os.path.join(data_dir, "cells")
 non_cell_cubes = os.path.join(data_dir, "non_cells")
 training_yaml_file = os.path.join(data_dir, "training.yaml")
 training_yaml_file_stats = os.path.join(data_dir, "training_with_stats.yaml")
+
+
+def test_cmd_args(mocker: MockerFixture, tmpdir):
+    """
+    Checks that training is run with expected set of parameters.
+    """
+    with patch("cellfinder.core.train.train_yaml.run") as train_yaml:
+        yaml_files = "a_file_1.yaml", "a_file_2.yaml"
+
+        train_args = [
+            "cellfinder_train",
+            "-y",
+            yaml_files[0],
+            yaml_files[1],
+            "-o",
+            str(tmpdir),
+            "--epochs",
+            "77",
+            "--batch-size",
+            "27",
+            "--test-fraction",
+            "0.21",
+            "--learning-rate",
+            "0.0023",
+            "--lr-schedule",
+            "12",
+            "37",
+            "57",
+            "--lr-multiplier",
+            "0.61",
+            "--augment-likelihood",
+            "0.83",
+            "--flippable-axis",
+            "0",
+            "2",
+            "--rotate-range",
+            "33",
+            "157",
+            "--translate-range",
+            "-0.33",
+            "0.47",
+            "--scale-range",
+            "0.67",
+            "1.37",
+            "--intensity-range",
+            "0.49",
+            "1.83",
+            "--n-free-cpus",
+            "7",
+        ]
+
+        mocker.patch("sys.argv", train_args)
+        train_run()
+
+        train_yaml.assert_called_once()
+        called_kwargs = train_yaml.call_args.kwargs
+
+        assert str(called_kwargs["output_dir"]) == str(tmpdir)
+        assert list(called_kwargs["yaml_file"]) == list(yaml_files)
+        assert called_kwargs["epochs"] == 77
+        assert called_kwargs["batch_size"] == 27
+        assert called_kwargs["test_fraction"] == 0.21
+        assert called_kwargs["learning_rate"] == 0.0023
+        assert list(called_kwargs["lr_schedule"]) == [12, 37, 57]
+        assert called_kwargs["lr_multiplier"] == 0.61
+        assert called_kwargs["augment_likelihood"] == 0.83
+        assert set(called_kwargs["flippable_axis"]) == {0, 2}
+        assert (
+            list(called_kwargs["rotate_range"])
+            == [
+                (33, 157),
+            ]
+            * 3
+        )
+        assert (
+            list(called_kwargs["translate_range"])
+            == [
+                (-0.33, 0.47),
+            ]
+            * 3
+        )
+        assert (
+            list(called_kwargs["scale_range"])
+            == [
+                (0.67, 1.37),
+            ]
+            * 3
+        )
+        assert list(called_kwargs["intensity_range"]) == [0.49, 1.83]
+        assert called_kwargs["n_free_cpus"] == 7
 
 
 EPOCHS = "2"

--- a/tests/core/test_unit/test_classify/test_data_augment.py
+++ b/tests/core/test_unit/test_classify/test_data_augment.py
@@ -4,7 +4,11 @@ import pytest
 import torch
 from monai.transforms import RandAffine
 
-from cellfinder.core.classify.augment import DataAugmentation
+from cellfinder.core.classify.augment import (
+    DataAugmentation,
+    interval_to_rand_range,
+    interval_to_rand_range_3d,
+)
 
 
 @pytest.fixture
@@ -23,7 +27,7 @@ def cube_with_side_dot() -> torch.Tensor:
 def cube_with_center_dot() -> torch.Tensor:
     # DataAugmentation.DIM_ORDER of (c, y, x, z)
     data = torch.zeros((2, 11, 11, 7))
-    data[:, 5, 5, 3] = 1
+    data[:, 4:7, 4:7, 2:5] = 1
     return data
 
 
@@ -183,7 +187,7 @@ def test_isotropy_round_trip(cube_with_side_dot):
             "translate_range",
             [(1 / 11, 1 / 11), (2 / 11, 2 / 11), (1 / 7, 1 / 7)],
         ),
-        ("rotate_range", [(0, 0), (0, 0), (math.pi / 2, math.pi / 2)]),
+        ("rotate_range", [(0, 0), (0, 0), (90, 90)]),
         ("scale_range", ((3, 3),) * 3),
         ("flippable_axis", (0, 1)),
     ],
@@ -200,16 +204,16 @@ def test_no_augment(cube_with_side_dot, name, value):
     assert (
         not augmenter.update_parameters()
     ), "Parameters should not be randomized"
-    assert not augmenter._do_affine
-    assert not augmenter._axes_to_flip
     augmented = augmenter(cube_with_side_dot)
 
     assert augmented.shape == cube_with_side_dot.shape
     assert torch.equal(cube_with_side_dot, augmented)
 
 
-@pytest.mark.parametrize("reorder", [False, True])
-def test_augment_translate(cube_with_side_dot, reorder):
+@pytest.mark.parametrize(
+    "reorder,translate_sign", [(False, 1), (True, 1), (False, -1)]
+)
+def test_augment_translate(cube_with_side_dot, reorder, translate_sign):
     """
     Test that translate augmentation works, with likelihood of 1.
 
@@ -217,6 +221,9 @@ def test_augment_translate(cube_with_side_dot, reorder):
     """
     c, y, x, z = cube_with_side_dot.shape
     translate_range = [(1 / 11, 1 / 11), (2 / 11, 2 / 11), (1 / 7, 1 / 7)]
+    translate_range = [
+        (translate_sign * s, translate_sign * e) for s, e in translate_range
+    ]
     data_dim_order = "c", "y", "x", "z"
     if reorder:
         data_dim_order = "c", "y", "z", "x"
@@ -230,23 +237,28 @@ def test_augment_translate(cube_with_side_dot, reorder):
     )
     assert augmenter.update_parameters(), "Parameters should be randomized"
     # affine is needed for translate/rotate/scale
-    assert augmenter._asked_affine
-    assert augmenter._do_affine
+    assert augmenter.needs_isotropic
+    assert augmenter._translate_trans is not None
     # the cube is not cube but cuboid, so need to make iso before transforming
     assert not augmenter._is_isotropic
-    assert not augmenter._axes_to_flip
     augmented = augmenter(cube_with_side_dot)
 
     assert augmented.shape == cube_with_side_dot.shape
     # check it was translated correctly converting percent to voxels offset
     assert augmented[0, 8, 8, 5] < 0.1
     assert augmented[1, 8, 2, 5] < 0.1
-    assert augmented[0, 8 + 1, 8 + 2, 5 + 1] > 0.1
-    assert augmented[1, 8 + 1, 2 + 2, 5 + 1] > 0.1
+    if translate_sign > 0:
+        assert augmented[0, 8 + 1, 8 + 2, 5 + 1] > 0.1
+        assert augmented[1, 8 + 1, 2 + 2, 5 + 1] > 0.1
+    else:
+        assert augmented[0, 8 - 1, 8 - 2, 5 - 1] > 0.1
+        assert augmented[1, 8 - 1, 2 - 2, 5 - 1] > 0.1
 
 
-@pytest.mark.parametrize("reorder", [False, True])
-def test_augment_rotate(cube_with_side_dot, reorder):
+@pytest.mark.parametrize(
+    "reorder,angle", [(False, 90), (True, 90), (False, -90)]
+)
+def test_augment_rotate(cube_with_side_dot, reorder, angle):
     """
     Test that rotation augmentation works, with likelihood of 1.
 
@@ -261,16 +273,15 @@ def test_augment_rotate(cube_with_side_dot, reorder):
     augmenter = DataAugmentation(
         volume_size={"x": x, "y": y, "z": z},
         augment_likelihood=1,
-        rotate_range=[(0, 0), (0, 0), (math.pi / 2, math.pi / 2)],
+        rotate_range=[(0, 0), (0, 0), (angle, angle)],
         data_dim_order=data_dim_order,
     )
     assert augmenter.update_parameters(), "Parameters should be randomized"
     # afine is needed for translate/rotate/scale
-    assert augmenter._asked_affine
-    assert augmenter._do_affine
+    assert augmenter.needs_isotropic
+    assert augmenter._rotate_trans is not None
     # the cube is not cube but cuboid, so need to make iso before transforming
     assert not augmenter._is_isotropic
-    assert not augmenter._axes_to_flip
     augmented = augmenter(cube_with_side_dot)
 
     assert augmented.shape == cube_with_side_dot.shape
@@ -293,8 +304,10 @@ def test_augment_rotate(cube_with_side_dot, reorder):
     )
 
 
-@pytest.mark.parametrize("reorder", [False, True])
-def test_augment_scale(cube_with_center_dot, reorder):
+@pytest.mark.parametrize(
+    "reorder,scale", [(False, 3), (True, 3), (False, 0.2)]
+)
+def test_augment_scale(cube_with_center_dot, reorder, scale):
     """
     Test that scaling augmentation works, with likelihood of 1.
 
@@ -309,61 +322,64 @@ def test_augment_scale(cube_with_center_dot, reorder):
     augmenter = DataAugmentation(
         volume_size={"x": x, "y": y, "z": z},
         augment_likelihood=1,
-        scale_range=((3, 3),) * 3,
+        scale_range=((scale, scale),) * 3,
         data_dim_order=data_dim_order,
     )
     assert augmenter.update_parameters(), "Parameters should be randomized"
     # affine is needed for translate/rotate/scale
-    assert augmenter._asked_affine
-    assert augmenter._do_affine
+    assert augmenter.needs_isotropic
+    assert augmenter._scale_trans is not None
     # the cube is not cube but cuboid, so need to make iso before transforming
     assert not augmenter._is_isotropic
-    assert not augmenter._axes_to_flip
     augmented = augmenter(cube_with_center_dot)
 
     assert augmented.shape == cube_with_center_dot.shape
-    assert augmented[0, 5, 5, 3] > 0.1
-    assert augmented[0, 5 + 1, 5, 3] > 0.1
-    assert augmented[0, 5, 5 + 1, 3] > 0.1
-    assert augmented[0, 5, 5, 3 + 1] > 0.1
+    for i in range(2):
+        if scale > 1:
+            assert augmented[i, 5, 5, 3] > 0.1
+            assert augmented[i, 5 + 3, 5, 3] > 0.1
+            assert augmented[i, 5, 5 + 3, 3] > 0.1
+            assert augmented[i, 5, 5, 3 + 3] > 0.1
+        else:
+            assert augmented[i, 5 + 1, 5, 3] < 0.1
+            assert augmented[i, 5, 5 + 1, 3] < 0.1
+            assert augmented[i, 5, 5, 3 + 1] < 0.1
 
-    assert augmented[1, 5, 5, 3] > 0.1
-    assert augmented[1, 5 + 1, 5, 3] > 0.1
-    assert augmented[1, 5, 5 + 1, 3] > 0.1
-    assert augmented[1, 5, 5, 3 + 1] > 0.1
 
-
-def test_affine_2_interval_same_as_single_value(cube_with_side_dot):
+@pytest.mark.parametrize(
+    "reorder,intensity_range",
+    [(False, (1.2, 1.2)), (True, (1.2, 1.2)), (False, (0.8, 0.8))],
+)
+def test_augment_intensity_multiply(
+    cube_with_center_dot, reorder, intensity_range
+):
     """
-    Checks that for all the affine transformations, using a 2-tuple interval
-    with the same value is the same as providing a single value.
-    """
-    c, y, x, z = cube_with_side_dot.shape
+    Test that intensity augmentation works, with likelihood of 1.
 
-    augmenter_1 = DataAugmentation(
+    With re-order we check that input data of different axes order works.
+    """
+    c, y, x, z = cube_with_center_dot.shape
+    data_dim_order = "c", "y", "x", "z"
+    if reorder:
+        data_dim_order = "c", "y", "z", "x"
+        z, x = x, z
+
+    augmenter = DataAugmentation(
         volume_size={"x": x, "y": y, "z": z},
         augment_likelihood=1,
-        translate_range=[1 / 11, 2 / 11, 1 / 7],
-        rotate_range=[0, 0, math.pi / 2],
-        scale_range=(3, 3, 3),
-        data_dim_order=DataAugmentation.DIM_ORDER,
+        intensity_range=intensity_range,
+        data_dim_order=data_dim_order,
     )
-    augmenter_2 = DataAugmentation(
-        volume_size={"x": x, "y": y, "z": z},
-        augment_likelihood=1,
-        translate_range=[(1 / 11, 1 / 11), (2 / 11, 2 / 11), (1 / 7, 1 / 7)],
-        rotate_range=[(0, 0), (0, 0), (math.pi / 2, math.pi / 2)],
-        scale_range=((3, 3),) * 3,
-        data_dim_order=DataAugmentation.DIM_ORDER,
-    )
-    assert augmenter_1.update_parameters()
-    assert augmenter_2.update_parameters()
+    assert augmenter.update_parameters(), "Parameters should be randomized"
+    # affine is needed for translate/rotate/scale
+    assert not augmenter.needs_isotropic
+    assert augmenter._intensity_range is not None
+    # the cube is not cube but cuboid
+    assert not augmenter._is_isotropic
+    augmented = augmenter(cube_with_center_dot)
 
-    augmented_1 = augmenter_1(cube_with_side_dot)
-    augmented_2 = augmenter_2(cube_with_side_dot)
-
-    assert not torch.allclose(cube_with_side_dot, augmented_1)
-    assert torch.allclose(augmented_1, augmented_2)
+    assert augmented.shape == cube_with_center_dot.shape
+    assert torch.allclose(cube_with_center_dot * intensity_range[0], augmented)
 
 
 @pytest.mark.parametrize("reorder", [False, True])
@@ -382,10 +398,7 @@ def test_augment_axis_flip(cube_with_side_dot, reorder):
     )
     assert augmenter.update_parameters(), "Parameters should be randomized"
     # afine is not needed when only flipping axes
-    assert not augmenter._asked_affine
-    assert not augmenter._do_affine
-    assert not augmenter._is_isotropic
-    assert augmenter._axes_to_flip
+    assert not augmenter.needs_isotropic
     augmented = augmenter(cube_with_side_dot)
 
     assert augmented.shape == cube_with_side_dot.shape
@@ -421,10 +434,8 @@ def test_channels_are_identically_augmented(reorder):
         data_dim_order=data_dim_order,
     )
     assert augmenter.update_parameters(), "Parameters should be randomized"
-    assert augmenter._asked_affine
-    assert augmenter._do_affine
+    assert augmenter.needs_isotropic
     assert not augmenter._is_isotropic
-    assert augmenter._axes_to_flip
 
     augmented = augmenter(data)
 
@@ -486,3 +497,49 @@ def test_augment_call_bad_input(cube_with_side_dot):
         augmenter(
             torch.empty((c, y + 1, x, z), dtype=cube_with_side_dot.dtype)
         )
+
+
+def test_interval_to_rand_range_3d():
+    assert (
+        interval_to_rand_range_3d(0, 1)
+        == [
+            (0, 1),
+        ]
+        * 3
+    )
+
+    assert interval_to_rand_range_3d(0.5, 0.5) is None
+    assert interval_to_rand_range_3d(1, 0.5) is None
+
+    assert (
+        interval_to_rand_range_3d(-5, 1, min_val=0)
+        == [
+            (0, 1),
+        ]
+        * 3
+    )
+    assert (
+        interval_to_rand_range_3d(0, 5, max_val=1)
+        == [
+            (0, 1),
+        ]
+        * 3
+    )
+    assert (
+        interval_to_rand_range_3d(-5, 5, min_val=0, max_val=1)
+        == [
+            (0, 1),
+        ]
+        * 3
+    )
+
+
+def test_interval_to_rand_range():
+    assert interval_to_rand_range(0, 1) == (0, 1)
+
+    assert interval_to_rand_range(0.5, 0.5) is None
+    assert interval_to_rand_range(1, 0.5) is None
+
+    assert interval_to_rand_range(-5, 1, min_val=0) == (0, 1)
+    assert interval_to_rand_range(0, 5, max_val=1) == (0, 1)
+    assert interval_to_rand_range(-5, 5, min_val=0, max_val=1) == (0, 1)

--- a/tests/napari/test_training.py
+++ b/tests/napari/test_training.py
@@ -1,5 +1,6 @@
+import sys
 from pathlib import Path
-from unittest.mock import ThreadingMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -94,10 +95,16 @@ def test_run_with_virtual_yaml_files(get_training_widget):
         )
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 13),
+    reason="requires ThreadingMock, only available in Python 3.13+",
+)
 def test_args_properly_set(get_training_widget):
     """
     Checks that training is run with parameters from GUI.
     """
+    from unittest.mock import ThreadingMock
+
     with patch(
         "cellfinder.napari.train.train.train_yaml", new_callable=ThreadingMock
     ) as train_yaml:

--- a/tests/napari/test_training.py
+++ b/tests/napari/test_training.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import ThreadingMock, patch
 
 import pytest
 
@@ -92,3 +92,70 @@ def test_run_with_virtual_yaml_files(get_training_widget):
             expected_optional_training_args,
             expected_misc_args,
         )
+
+
+def test_args_properly_set(get_training_widget):
+    """
+    Checks that training is run with parameters from GUI.
+    """
+    with patch(
+        "cellfinder.napari.train.train.train_yaml", new_callable=ThreadingMock
+    ) as train_yaml:
+        # make default input valid - need yaml files (they don't technically
+        # have to exist)
+        virtual_yaml_files = (
+            Path.home() / "file_1.yaml",
+            Path.home() / "file_2.yaml",
+        )
+        get_training_widget.yaml_files.value = virtual_yaml_files
+        get_training_widget.epochs.value = 77
+        get_training_widget.batch_size.value = 27
+        get_training_widget.test_fraction.value = 0.21
+        get_training_widget.learning_rate.value = 0.0023
+        get_training_widget.lr_schedule.value = [12, 37, 57]
+        get_training_widget.lr_multiplier.value = 0.61
+        get_training_widget.augment_likelihood.value = 0.83
+        get_training_widget.flippable_axis.value = [0, 2]
+        get_training_widget.rotate_range.value = 33, 145
+        get_training_widget.translate_range.value = -0.33, 0.47
+        get_training_widget.scale_range.value = 0.67, 1.37
+        get_training_widget.intensity_range.value = 0.49, 1.83
+        get_training_widget.number_of_free_cpus.value = 7
+        get_training_widget.call_button.clicked()
+
+        train_yaml.wait_until_called(timeout=60)
+        train_yaml.assert_called_once()
+        called_kwargs = train_yaml.call_args.kwargs
+
+        assert list(called_kwargs["yaml_file"]) == list(virtual_yaml_files)
+        assert called_kwargs["epochs"] == 77
+        assert called_kwargs["batch_size"] == 27
+        assert called_kwargs["test_fraction"] == 0.21
+        assert called_kwargs["learning_rate"] == 0.0023
+        assert list(called_kwargs["lr_schedule"]) == [12, 37, 57]
+        assert called_kwargs["lr_multiplier"] == 0.61
+        assert called_kwargs["augment_likelihood"] == 0.83
+        assert set(called_kwargs["flippable_axis"]) == {0, 2}
+        assert (
+            list(called_kwargs["rotate_range"])
+            == [
+                (33, 145),
+            ]
+            * 3
+        )
+        assert (
+            list(called_kwargs["translate_range"])
+            == [
+                (-0.33, 0.47),
+            ]
+            * 3
+        )
+        assert (
+            list(called_kwargs["scale_range"])
+            == [
+                (0.67, 1.37),
+            ]
+            * 3
+        )
+        assert list(called_kwargs["intensity_range"]) == [0.49, 1.83]
+        assert called_kwargs["n_free_cpus"] == 7


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

1. Currently, all the augmentation parameters are hard-coded, which is not ideal if you want to change them.
2. There are three affine transformations: scale, translate, and rotate. Currently, they all happen together. I.e. if we do affine, then we do all three (although they each have their own random intervals of course). Ideally, we would randomly apply each independently so there's no dependence between them at all.
3. Data has different intensities, we should have an augmentation that lets you randomly scale the intensity of the sample volume.

**What does this PR do?**

1. It exposes all the augmentation parameters in napari and on the command line.
   i. I restored the augmentation parameter defaults back to what they were before any augmentation changes
      https://github.com/brainglobe/cellfinder/blob/de4d498cd0a99248752f12bddf7f0cf948edbc10/cellfinder/core/classify/cube_generator.py#L52-L56
      There, `scale` was disabled completely, `translate` happened in a +/- `0.05` interval (although I think we should not do any translation because the we care about the cell being in the center and sometimes detected center is already offset so any additional translation may shift the detected center to be outside the cell, making it a incorrect training example), `rotation` was minimal in the +/- `1` degree interval. Of course the augmentation, listed as `0.1` was actually `0.9`.
      
      In main, due to the recent PR, it is slightly different. Specifically the scale is enabled and the rotation defaults to a larger angle. So I restored it to the old values.
2. The affine transformations are now all independent augmentations and are independently sampled so there's no dependence between them.
3. I added an augmentation that lets you scale the cuboid intensity by a random factor, similar to the other augmentations.
4. I also dropped the augmentation parameter syntax internally that let you specify e.g. `0.05` instead of having to write out `(-0.05, 0.05)`. Because it was just adding more complexity and doesn't help much because from the Napari and cli we always specify an interval. Plus for translation, there was a bug in this single value from.

## References

https://github.com/brainglobe/cellfinder/issues/587 we talked about finding a better value for likelihood. IMO we should change the augmentation default parameters to something like `0-360` for `rotation`, `translation` `disabled`, `scaling` `0.9-1.25`, and `intensity` `0.5-2`. And for likelihood something like `0.8`. But that's for the future, unless we're okay changing it here.

## How has this PR been tested?

I added more tests and corrected older tests for the changes. Plus, you can see below training main vs this PR on my data and they perform similarly. You'll notice I ran this PR twice because the first run it took a bit for the network to find the right gradients. But this is simply due to randomness IMO.

<img width="4178" height="1683" alt="loss" src="https://github.com/user-attachments/assets/1800e871-9bff-4c20-90e2-9ba613a97ae8" />
<img width="4177" height="1727" alt="accuracy" src="https://github.com/user-attachments/assets/ba51e70b-6ba3-4edf-80a9-bc66fcd51a93" />


## Is this a breaking change?

Only that we restored the default parameters to what they were.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
