### PR TITLE
Curated tiff directories in yaml file should be relative to yaml file

### DIFF
--- a/cellfinder/core/train/train_yaml.py
+++ b/cellfinder/core/train/train_yaml.py
@@ -298,14 +298,29 @@ def training_parse():
     return args
 
 
-def parse_yaml(yaml_files, section="data"):
+def parse_yaml(
+    yaml_files: list[str | Path], section="data"
+) -> list[tuple[Path, dict]]:
     data = []
     for yaml_file in yaml_files:
-        data.extend(read_yaml_section(yaml_file, section))
+        for group in read_yaml_section(yaml_file, section):
+            data.append((Path(yaml_file), group))
     return data
 
 
-def get_tiff_files(yaml_contents: list[dict]) -> list[list[TiffFile]]:
+def _abs_or_rel_path_to_abs(path: Path, root_file: Path) -> Path:
+    """
+    Return the `path` if it's an absolute path, otherwise, the `path` is
+    relative to the `root_file`.
+    """
+    if path.is_absolute():
+        return path
+    return (root_file.parent / path).resolve()
+
+
+def get_tiff_files(
+    yaml_contents: list[tuple[Path, dict]],
+) -> list[list[TiffFile]]:
     """
     Takes a yaml file representing multiple folders each containing many
     extracted cube tiff files. It returns a corresponding list of lists of
@@ -313,7 +328,7 @@ def get_tiff_files(yaml_contents: list[dict]) -> list[list[TiffFile]]:
     the given directory.
     """
     tiff_lists = []
-    for d in yaml_contents:
+    for yaml_f, d in yaml_contents:
         if d["bg_channel"] < 0:
             channels = [d["signal_channel"]]
             channels_metadata = [
@@ -335,12 +350,13 @@ def get_tiff_files(yaml_contents: list[dict]) -> list[list[TiffFile]]:
                 "std": float(d["bg_std"]),
             }
 
+        cube_dir = _abs_or_rel_path_to_abs(Path(d["cube_dir"]), yaml_f)
         if "cell_def" in d and d["cell_def"]:
-            ch1_tiffs = [
-                os.path.join(d["cube_dir"], f)
-                for f in os.listdir(d["cube_dir"])
-                if f.endswith("Ch" + str(channels[0]) + ".tif")
-            ]
+            ch1_tiffs = []
+            for f in os.listdir(cube_dir):
+                if f.endswith("Ch" + str(channels[0]) + ".tif"):
+                    ch1_tiffs.append(str(cube_dir / f))
+
             tiff_lists.append(
                 TiffList(
                     find_relevant_tiffs(ch1_tiffs, d["cell_def"]),
@@ -351,7 +367,7 @@ def get_tiff_files(yaml_contents: list[dict]) -> list[list[TiffFile]]:
             )
         else:
             tiff_lists.append(
-                TiffDir(d["cube_dir"], channels, channels_metadata, d["type"])
+                TiffDir(str(cube_dir), channels, channels_metadata, d["type"])
             )
 
     tiff_files = [tiff_dir.make_tifffile_list() for tiff_dir in tiff_lists]

--- a/cellfinder/napari/curation.py
+++ b/cellfinder/napari/curation.py
@@ -672,9 +672,23 @@ class CurationWidget(QWidget):
 
     def __save_yaml_file(self):
         signal_stat, bg_stat = self._calculate_channel_stats()
+
+        cells_dir = self.cell_cube_dir.relative_to(self.yaml_filename.parent)
+        non_cells_dir = self.no_cell_cube_dir.relative_to(
+            self.yaml_filename.parent
+        )
+
+        # napari includes the filename if the image layer came from a file
+        sig_source = ""
+        if self.signal_layer.source and self.signal_layer.source.path:
+            sig_source = str(Path(self.signal_layer.source.path.resolve()))
+        bg_source = ""
+        if self.background_layer.source and self.background_layer.source.path:
+            bg_source = str(Path(self.background_layer.source.path.resolve()))
+
         yaml_section = [
             {
-                "cube_dir": str(self.cell_cube_dir),
+                "cube_dir": str(cells_dir),
                 "cell_def": "",
                 "type": "cell",
                 "signal_channel": 0,
@@ -683,9 +697,11 @@ class CurationWidget(QWidget):
                 "signal_std": signal_stat[1],
                 "bg_mean": bg_stat[0],
                 "bg_std": bg_stat[1],
+                "signal_source": sig_source,
+                "background_source": bg_source,
             },
             {
-                "cube_dir": str(self.no_cell_cube_dir),
+                "cube_dir": str(non_cells_dir),
                 "cell_def": "",
                 "type": "no_cell",
                 "signal_channel": 0,
@@ -694,6 +710,8 @@ class CurationWidget(QWidget):
                 "signal_std": signal_stat[1],
                 "bg_mean": bg_stat[0],
                 "bg_std": bg_stat[1],
+                "signal_source": sig_source,
+                "background_source": bg_source,
             },
         ]
 

--- a/tests/napari/test_curation.py
+++ b/tests/napari/test_curation.py
@@ -1,3 +1,5 @@
+import os
+import shutil
 from pathlib import Path
 from unittest.mock import patch
 
@@ -7,6 +9,7 @@ import pytest
 import yaml
 from napari.layers import Image, Points
 
+from cellfinder.core.train.train_yaml import get_tiff_files, parse_yaml
 from cellfinder.napari import sample_data
 from cellfinder.napari.curation import CurationWidget
 from cellfinder.napari.sample_data import load_sample
@@ -109,7 +112,8 @@ def test_cell_marking(curation_widget, tmp_path):
         yaml_data = yaml.safe_load(fh)
 
     for item in yaml_data["data"]:
-        assert "cube_dir" in item
+        # the cube dir should be relative to yaml file not an abs path
+        assert not Path(item["cube_dir"]).is_absolute()
         assert "signal_channel" in item
         assert "bg_channel" in item
         assert "type" in item
@@ -117,6 +121,8 @@ def test_cell_marking(curation_widget, tmp_path):
         assert "signal_std" in item
         assert "bg_mean" in item
         assert "bg_std" in item
+        assert "signal_source" in item
+        assert "background_source" in item
 
 
 @pytest.fixture
@@ -290,10 +296,68 @@ def test_async_save_done_only_after_cubes_written(
         assert show_info.call_args_list == []
         assert not (tmp_path / "training.yaml").exists()
 
-        qtbot.waitUntil(
-            lambda: (tmp_path / "training.yaml").exists(), timeout=20000
-        )
+        qtbot.waitUntil(lambda: show_info.call_count, timeout=20000)
 
         show_info.assert_called_once_with("Done")
-        assert len(list((tmp_path / "cells").glob("*.tif"))) == 2
-        assert len(list((tmp_path / "non_cells").glob("*.tif"))) == 2
+
+    assert (tmp_path / "training.yaml").exists()
+    assert len(list((tmp_path / "cells").glob("*.tif"))) == 2
+    assert len(list((tmp_path / "non_cells").glob("*.tif"))) == 2
+
+
+def test_curated_data_can_be_loaded(valid_curation_widget, tmp_path, qtbot):
+    """
+    Tests that the curated data can be loaded by training code. Both in its
+    original exported location and after it has been moved elsewhere.
+    """
+    widget = valid_curation_widget
+    widget.output_directory = tmp_path
+
+    with patch("cellfinder.napari.curation.show_info") as show_info:
+        widget.save_training_data(prompt_for_directory=False, block=False)
+
+        assert not (tmp_path / "training.yaml").exists()
+
+        qtbot.waitUntil(lambda: show_info.call_count, timeout=20000)
+
+    # check that we can load the training data where it currently exists
+    training_yaml = tmp_path / "training.yaml"
+    src_tiffs = {f.resolve() for f in tmp_path.glob("**/*.tif")}
+
+    assert training_yaml.exists()
+    assert len(src_tiffs) == 4
+
+    # check read tiffs are same
+    yaml_contents = parse_yaml([str(training_yaml)])
+    tiff_lists = get_tiff_files(yaml_contents)
+    loaded_tiffs = {
+        f for group in tiff_lists for im in group for f in im.img_files
+    }
+    for f in loaded_tiffs:
+        assert Path(f).exists()
+
+    assert {Path(f).resolve() for f in loaded_tiffs} == src_tiffs
+
+    # now move the data and check that we can still load it
+    items = os.listdir(tmp_path)
+    new_place = tmp_path / "new_place"
+    new_place.mkdir()
+    for item in items:
+        shutil.move(tmp_path / item, new_place)
+
+    training_yaml = new_place / "training.yaml"
+    moved_tiffs = {f.resolve() for f in new_place.glob("**/*.tif")}
+
+    assert training_yaml.exists()
+    assert {f.name for f in moved_tiffs} == {f.name for f in src_tiffs}
+
+    # check read tiffs are same
+    yaml_contents = parse_yaml([str(training_yaml)])
+    tiff_lists = get_tiff_files(yaml_contents)
+    loaded_tiffs = {
+        f for group in tiff_lists for im in group for f in im.img_files
+    }
+    for f in loaded_tiffs:
+        assert Path(f).exists()
+
+    assert {Path(f).resolve() for f in loaded_tiffs} == moved_tiffs


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Currently, after exporting the curated cuboids, if you move the exported data elsewhere (such as another computer) and then try to use the yaml for training, it'll error out because the paths in the yaml file for the tiff directories are absolute. This is annoying because you have to manually adjust the paths in all the yaml files every time you move them.

Here's a test I added to the branch, which when run on main results in the following error, which similarly happens if you try to use a yaml file after it has been moved from the location where data was originally exported:

```sh
tests\napari\test_curation.py F                                                                                                                                                                            [100%]

=================================================================================================== FAILURES ====================================================================================================
________________________________________________________________________________________ test_curated_data_can_be_loaded ________________________________________________________________________________________

valid_curation_widget = <cellfinder.napari.curation.CurationWidget object at 0x00000289DB0F7B10>, tmp_path = WindowsPath('C:/msys64/tmp/pytest-of-CPLab/pytest-30/test_curated_data_can_be_loade0')
qtbot = <pytestqt.qtbot.QtBot object at 0x000002898AE3AA50>

    def test_curated_data_can_be_loaded(valid_curation_widget, tmp_path, qtbot):
        """
        Tests that the curated data can be loaded by training code. Both in its
        original exported location and after it has been moved elsewhere.
        """
        widget = valid_curation_widget
        widget.output_directory = tmp_path

        with patch("cellfinder.napari.curation.show_info") as show_info:
            widget.save_training_data(prompt_for_directory=False, block=False)

            assert not (tmp_path / "training.yaml").exists()

            qtbot.waitUntil(lambda: show_info.call_count, timeout=20000)

        # check that we can load the training data where it currently exists
        training_yaml = tmp_path / "training.yaml"
        src_tiffs = {f.resolve() for f in tmp_path.glob("**/*.tif")}

        assert training_yaml.exists()
        assert len(src_tiffs) == 4

        # check read tiffs are same
        yaml_contents = parse_yaml([str(training_yaml)])
        tiff_lists = get_tiff_files(yaml_contents)
        loaded_tiffs = {
            f for group in tiff_lists for im in group for f in im.img_files
        }
        for f in loaded_tiffs:
            assert Path(f).exists()

        assert {Path(f).resolve() for f in loaded_tiffs} == src_tiffs

        # now move the data and check that we can still load it
        items = os.listdir(tmp_path)
        new_place = tmp_path / "new_place"
        new_place.mkdir()
        for item in items:
            shutil.move(tmp_path / item, new_place)

        training_yaml = new_place / "training.yaml"
        moved_tiffs = {f.resolve() for f in new_place.glob("**/*.tif")}

        assert training_yaml.exists()
        assert {f.name for f in moved_tiffs} == {f.name for f in src_tiffs}

        # check read tiffs are same
        yaml_contents = parse_yaml([str(training_yaml)])
>       tiff_lists = get_tiff_files(yaml_contents)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

tests\napari\test_curation.py:353:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
cellfinder\core\train\train_yaml.py:354: in get_tiff_files
    TiffDir(d["cube_dir"], channels, channels_metadata, d["type"])
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <cellfinder.core.tools.tiff.TiffDir object at 0x00000289DB4FC190>, tiff_dir = 'C:\\msys64\\tmp\\pytest-of-CPLab\\pytest-30\\test_curated_data_can_be_loade0\\cells', channels = [0, 1]
channels_metadata = [{'mean': 262.34832005565846, 'std': 205.0074719217545}, {'mean': 214.4578158959736, 'std': 145.9514501306045}], label = 'cell'

    def __init__(
        self,
        tiff_dir: str,
        channels: list[int],
        channels_metadata: list[dict],
        label: str | None = None,
    ):
        super(TiffDir, self).__init__(
            [
                join(tiff_dir, f)
>               for f in listdir(tiff_dir)
                         ^^^^^^^^^^^^^^^^^
                if f.lower().endswith("ch" + str(channels[0]) + ".tif")
            ],
            channels,
            channels_metadata,
            label,
        )
E       FileNotFoundError: [WinError 3] The system cannot find the path specified: 'C:\\msys64\\tmp\\pytest-of-CPLab\\pytest-30\\test_curated_data_can_be_loade0\\cells'

cellfinder\core\tools\tiff.py:74: FileNotFoundError
```

**What does this PR do?**

1. This branch saves the tiff directories in the yaml as being relative to the `training.yaml` file. I'm assuming that when people move training data they move it as a whole so the yaml file will always have the same relationship to the directories as when originally exported.
2. I also added a key to the yaml file pointing to the original data filename from which the cubes came from, if that is available.  Napari keeps track of the filename from which an image layer comes from, if it is available. The key is not used anywhere, but is helpful if you want to know where the data came from.
3. I also adjusted `test_async_save_done_only_after_cubes_written`, because we should be checking for the done message to appear, not for the yaml file to be written because we can't assume `training.yaml` is the last file that gets saved.

## References

None.

## How has this PR been tested?

Added tests.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
