### PR TITLE
Make the background channel optional in the napari plugin

### DIFF
--- a/cellfinder/core/classify/classify.py
+++ b/cellfinder/core/classify/classify.py
@@ -125,9 +125,10 @@ def main(
         signal_normalization = dataset_mean_std(
             signal_array, normalization_n_sampling_planes
         )
-        background_normalization = dataset_mean_std(
-            background_array, normalization_n_sampling_planes
-        )
+        if background_array is not None:
+            background_normalization = dataset_mean_std(
+                background_array, normalization_n_sampling_planes
+            )
         logger.debug(
             f"Signal channel norm is: {signal_normalization}. "
             f"Background channel norm is: {background_normalization}"

--- a/cellfinder/core/main.py
+++ b/cellfinder/core/main.py
@@ -212,6 +212,8 @@ def main(
             raise FileNotFoundError(
                 f"Trained model not found: {trained_model}"
             )
+        if background_array is None and model == "resnet50_tv":
+            model = "resnet50_1ch"
         install_path = None
         model_weights = prep.prep_model_weights(
             model_weights, install_path, model

--- a/cellfinder/napari/curation.py
+++ b/cellfinder/napari/curation.py
@@ -40,6 +40,8 @@ WINDOW_HEIGHT = 750
 WINDOW_WIDTH = 1500
 COLUMN_WIDTH = 150
 
+NO_BACKGROUND_CHANNEL = -1
+
 
 class CurationWidget(QWidget):
     """
@@ -115,14 +117,11 @@ class CurationWidget(QWidget):
         @self.viewer.layers.events.removed.connect
         def _remove_selection_layers(event: QtCore.QEvent):
             """
-            Set internal background, signal, training data cell,
-            and training data non-cell layers to None when they
-            are removed from the napari viewer GUI.
+            Set the internal training data cell and non-cell layers to
+            None when they are removed from the napari viewer GUI. The
+            signal and background layers are reset through their combobox
+            callbacks (`set_signal_image` / `set_background_image`).
             """
-            if event.value == self.signal_layer:
-                self.signal_layer = None
-            if event.value == self.background_layer:
-                self.background_layer = None
             if event.value == self.training_data_cell_layer:
                 self.training_data_cell_layer = None
             if event.value == self.training_data_non_cell_layer:
@@ -314,6 +313,8 @@ class CurationWidget(QWidget):
             self.signal_layer = self.viewer.layers[
                 self.signal_image_choice.currentText()
             ]
+        else:
+            self.signal_layer = None
 
     def set_background_image(self):
         """
@@ -323,6 +324,8 @@ class CurationWidget(QWidget):
             self.background_layer = self.viewer.layers[
                 self.background_image_choice.currentText()
             ]
+        else:
+            self.background_layer = None
 
     def set_training_data_cell(self):
         """
@@ -544,6 +547,14 @@ class CurationWidget(QWidget):
         show_info("Done")
         self.update_status_label("Ready")
 
+    @property
+    def has_background(self) -> bool:
+        return self.background_layer is not None
+
+    @property
+    def background_data(self):
+        return self.background_layer.data if self.has_background else None
+
     def is_data_extractable(self) -> bool:
         if (
             self.check_training_data_exists()
@@ -554,25 +565,23 @@ class CurationWidget(QWidget):
             return False
 
     def check_image_data_for_extraction(self) -> bool:
-        if self.signal_layer and self.background_layer:
-            if (
-                self.signal_layer.data.shape
-                == self.background_layer.data.shape
-            ):
-                return True
-            else:
-                show_info(
-                    "Please ensure both signal and background images are the "
-                    "same size and shape.",
-                )
-                return False
-
-        else:
+        if not self.signal_layer:
             show_info(
-                "Please ensure both signal and background images are loaded "
-                "into napari, and selected in the sidebar. ",
+                "Please ensure a signal image is loaded into napari, and "
+                "selected in the sidebar. ",
             )
             return False
+
+        if self.has_background and (
+            self.signal_layer.data.shape != self.background_layer.data.shape
+        ):
+            show_info(
+                "Please ensure both signal and background images are the "
+                "same size and shape.",
+            )
+            return False
+
+        return True
 
     def check_training_data_exists(self) -> bool:
         """
@@ -664,6 +673,8 @@ class CurationWidget(QWidget):
         signal_stat = dataset_mean_std(
             self.signal_layer.data, self.normalization_n_sampling_planes
         )
+        if not self.has_background:
+            return signal_stat, None
         self.update_status_label("Estimating background mean/std...")
         bg_stat = dataset_mean_std(
             self.background_layer.data, self.normalization_n_sampling_planes
@@ -672,29 +683,26 @@ class CurationWidget(QWidget):
 
     def __save_yaml_file(self):
         signal_stat, bg_stat = self._calculate_channel_stats()
+        bg_channel = 1 if self.has_background else NO_BACKGROUND_CHANNEL
+
+        def cube_section(cube_dir, cube_type):
+            section = {
+                "cube_dir": str(cube_dir),
+                "cell_def": "",
+                "type": cube_type,
+                "signal_channel": 0,
+                "bg_channel": bg_channel,
+                "signal_mean": signal_stat[0],
+                "signal_std": signal_stat[1],
+            }
+            if bg_stat is not None:
+                section["bg_mean"] = bg_stat[0]
+                section["bg_std"] = bg_stat[1]
+            return section
+
         yaml_section = [
-            {
-                "cube_dir": str(self.cell_cube_dir),
-                "cell_def": "",
-                "type": "cell",
-                "signal_channel": 0,
-                "bg_channel": 1,
-                "signal_mean": signal_stat[0],
-                "signal_std": signal_stat[1],
-                "bg_mean": bg_stat[0],
-                "bg_std": bg_stat[1],
-            },
-            {
-                "cube_dir": str(self.no_cell_cube_dir),
-                "cell_def": "",
-                "type": "no_cell",
-                "signal_channel": 0,
-                "bg_channel": 1,
-                "signal_mean": signal_stat[0],
-                "signal_std": signal_stat[1],
-                "bg_mean": bg_stat[0],
-                "bg_std": bg_stat[1],
-            },
+            cube_section(self.cell_cube_dir, "cell"),
+            cube_section(self.no_cell_cube_dir, "no_cell"),
         ]
 
         yaml_contents = {"data": yaml_section}
@@ -729,6 +737,8 @@ class CurationWidget(QWidget):
             "non_cells": self.no_cell_cube_dir,
         }
 
+        background_array = self.background_data
+
         for cell_type in ["cells", "non_cells"]:
             cell_type_output_directory = directories[cell_type]
             cell_list = to_extract[cell_type]
@@ -737,7 +747,7 @@ class CurationWidget(QWidget):
 
             cube_generator = CuboidArrayDataset(
                 signal_array=self.signal_layer.data,
-                background_array=self.background_layer.data,
+                background_array=background_array,
                 points=cell_list,
                 data_voxel_sizes=self.voxel_sizes,
                 network_voxel_sizes=self.network_voxel_sizes,

--- a/cellfinder/napari/detect/detect.py
+++ b/cellfinder/napari/detect/detect.py
@@ -261,7 +261,8 @@ def detect_widget() -> FunctionGui:
         soma_spread_factor: float,
         max_cluster_size: float,
         classification_options,
-        model_source: ModelSource,
+        skip_classification: bool,
+        use_pre_trained_weights: bool,
         trained_model: Optional[Path],
         classification_batch_size: int,
         normalize_channels: bool,
@@ -336,12 +337,14 @@ def detect_widget() -> FunctionGui:
             Largest detected cell cluster (in cubic um) where splitting
             should be attempted. Clusters above this size will be labeled
             as artifacts
-        model_source : ModelSource
-            Which classification model to run: the pretrained default, a
-            custom model file, or skip classification entirely
+        skip_classification : bool
+            If selected, the classification step is skipped and all cells from
+            the detection stage are added
+        use_pre_trained_weights : bool
+            Select to use pre-trained model weights
         trained_model : Optional[Path]
-            Trained model file path, used only when model_source is a custom
-            model
+            Trained model file path, used only when pre-trained weights are
+            not selected
         classification_batch_size : int
             How many potential cells to classify at one time. The GPU/CPU
             memory must be able to contain at once this many data cubes for
@@ -396,13 +399,15 @@ def detect_widget() -> FunctionGui:
             show_info("Signal image must be specified.")
             return
 
-        skip_classification = model_source is ModelSource.SKIP
+        model_source = ModelSource.from_options(
+            skip_classification, use_pre_trained_weights
+        )
         if model_source is ModelSource.CUSTOM and not (
             trained_model and Path(trained_model).is_file()
         ):
             show_info(
-                "Select a trained model file, or choose "
-                "'Pretrained default' to use the default model."
+                "Select a trained model file, or check "
+                "'Use pre-trained weights' to use the default model."
             )
             return
 
@@ -450,7 +455,8 @@ def detect_widget() -> FunctionGui:
         )
 
         classification_inputs = ClassificationInputs(
-            model_source,
+            skip_classification,
+            use_pre_trained_weights,
             trained_model,
             classification_batch_size,
             normalize_channels,

--- a/cellfinder/napari/detect/detect.py
+++ b/cellfinder/napari/detect/detect.py
@@ -401,12 +401,13 @@ def detect_widget() -> FunctionGui:
         if (
             options["background_image"] is None
             and not skip_classification
-            and use_pre_trained_weights
+            and not use_pre_trained_weights
         ):
             show_info(
                 "Running without a background image needs a single-channel "
-                "model. Enable 'Skip classification', or uncheck 'Use "
-                "pre-trained weights' and select a single-channel model."
+                "model. Enable 'Use pre-trained weights' to use the default "
+                "single-channel model, enable 'Skip classification', or "
+                "select a single-channel trained model."
             )
             return
 

--- a/cellfinder/napari/detect/detect.py
+++ b/cellfinder/napari/detect/detect.py
@@ -27,6 +27,7 @@ from .detect_containers import (
     DataInputs,
     DetectionInputs,
     MiscInputs,
+    ModelSource,
 )
 from .thread_worker import Worker
 
@@ -260,8 +261,7 @@ def detect_widget() -> FunctionGui:
         soma_spread_factor: float,
         max_cluster_size: float,
         classification_options,
-        skip_classification: bool,
-        use_pre_trained_weights: bool,
+        model_source: ModelSource,
         trained_model: Optional[Path],
         classification_batch_size: int,
         normalize_channels: bool,
@@ -336,14 +336,12 @@ def detect_widget() -> FunctionGui:
             Largest detected cell cluster (in cubic um) where splitting
             should be attempted. Clusters above this size will be labeled
             as artifacts
-        skip_classification : bool
-            If selected, the classification step is skipped and all cells from
-            the detection stage are added
-        use_pre_trained_weights : bool
-            Select to use pre-trained model weights
+        model_source : ModelSource
+            Which classification model to run: the pretrained default, a
+            custom model file, or skip classification entirely
         trained_model : Optional[Path]
-            Trained model file path (home directory (default) -> pretrained
-            weights)
+            Trained model file path, used only when model_source is a custom
+            model
         classification_batch_size : int
             How many potential cells to classify at one time. The GPU/CPU
             memory must be able to contain at once this many data cubes for
@@ -398,16 +396,13 @@ def detect_widget() -> FunctionGui:
             show_info("Signal image must be specified.")
             return
 
-        if (
-            options["background_image"] is None
-            and not skip_classification
-            and not use_pre_trained_weights
+        skip_classification = model_source is ModelSource.SKIP
+        if model_source is ModelSource.CUSTOM and not (
+            trained_model and Path(trained_model).is_file()
         ):
             show_info(
-                "Running without a background image needs a single-channel "
-                "model. Enable 'Use pre-trained weights' to use the default "
-                "single-channel model, enable 'Skip classification', or "
-                "select a single-channel trained model."
+                "Select a trained model file, or choose "
+                "'Pretrained default' to use the default model."
             )
             return
 
@@ -454,11 +449,8 @@ def detect_widget() -> FunctionGui:
             detection_batch_size,
         )
 
-        if use_pre_trained_weights:
-            trained_model = None
         classification_inputs = ClassificationInputs(
-            skip_classification,
-            use_pre_trained_weights,
+            model_source,
             trained_model,
             classification_batch_size,
             normalize_channels,

--- a/cellfinder/napari/detect/detect.py
+++ b/cellfinder/napari/detect/detect.py
@@ -508,6 +508,21 @@ def detect_widget() -> FunctionGui:
         partial(restore_options_defaults, widget)
     )
 
+    def update_trained_model_visibility() -> None:
+        widget.trained_model.visible = (
+            ModelSource.from_options(
+                widget.skip_classification.value,
+                widget.use_pre_trained_weights.value,
+            )
+            is ModelSource.CUSTOM
+        )
+
+    widget.skip_classification.changed.connect(update_trained_model_visibility)
+    widget.use_pre_trained_weights.changed.connect(
+        update_trained_model_visibility
+    )
+    update_trained_model_visibility()
+
     # Insert progress bar before the run and reset buttons
     widget.insert(widget.index("debug") + 1, progress_bar)
 

--- a/cellfinder/napari/detect/detect.py
+++ b/cellfinder/napari/detect/detect.py
@@ -80,15 +80,16 @@ def get_heavy_widgets(
         auto_call=True,
     )
     def background_image_opt(
-        background_image: napari.layers.Image,
+        background_image: Optional[napari.layers.Image],
     ):
         """
         magicgui widget for setting the background image parameter.
 
         Parameters
         ----------
-        background_image : napari.layers.Image
-             Image layer without labelled cells
+        background_image : napari.layers.Image, optional
+             Image layer without labelled cells. Leave empty to run
+             single-channel detection and classification.
         """
         options["background_image"] = background_image
 
@@ -393,8 +394,20 @@ def detect_widget() -> FunctionGui:
 
         signal_image = options["signal_image"]
 
-        if signal_image is None or options["background_image"] is None:
-            show_info("Both signal and background images must be specified.")
+        if signal_image is None:
+            show_info("Signal image must be specified.")
+            return
+
+        if (
+            options["background_image"] is None
+            and not skip_classification
+            and use_pre_trained_weights
+        ):
+            show_info(
+                "Running without a background image needs a single-channel "
+                "model. Enable 'Skip classification', or uncheck 'Use "
+                "pre-trained weights' and select a single-channel model."
+            )
             return
 
         detected_cells = []
@@ -411,9 +424,14 @@ def detect_widget() -> FunctionGui:
                 options["cell_layer"], Cell.UNKNOWN
             )
 
+        background_image = options["background_image"]
+        background_array = (
+            background_image.data if background_image is not None else None
+        )
+
         data_inputs = DataInputs(
             signal_image.data,
-            options["background_image"].data,
+            background_array,
             voxel_size_z,
             voxel_size_y,
             voxel_size_x,

--- a/cellfinder/napari/detect/detect_containers.py
+++ b/cellfinder/napari/detect/detect_containers.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass, field
+from enum import Enum
 from pathlib import Path
 from typing import List, Optional
 
@@ -121,33 +122,40 @@ class DetectionInputs(InputContainer):
         )
 
 
+class ModelSource(Enum):
+    PRETRAINED = "Pretrained default"
+    CUSTOM = "Custom model"
+    SKIP = "Skip classification"
+
+
 @dataclass
 class ClassificationInputs(InputContainer):
     """Container for classification inputs."""
 
-    skip_classification: bool = False
-    use_pre_trained_weights: bool = True
+    model_source: ModelSource = ModelSource.PRETRAINED
     trained_model: Optional[Path] = Path.home()
     classification_batch_size: int = 64
     normalize_channels: bool = False
     normalization_n_sampling_planes: int = 50
 
+    @property
+    def skip_classification(self) -> bool:
+        return self.model_source is ModelSource.SKIP
+
     def as_core_arguments(self) -> dict:
         args = super().as_core_arguments()
-        del args["use_pre_trained_weights"]
+        args["skip_classification"] = self.skip_classification
+        if self.model_source is not ModelSource.CUSTOM:
+            args["trained_model"] = None
+        del args["model_source"]
         return args
 
     @classmethod
     def widget_representation(cls) -> dict:
         return dict(
             classification_options=html_label_widget("Classification:"),
-            use_pre_trained_weights=dict(
-                value=cls.defaults()["use_pre_trained_weights"]
-            ),
+            model_source=dict(value=cls.defaults()["model_source"]),
             trained_model=dict(value=cls.defaults()["trained_model"]),
-            skip_classification=dict(
-                value=cls.defaults()["skip_classification"]
-            ),
             classification_batch_size=dict(
                 value=cls.defaults()["classification_batch_size"],
                 label="Batch size (classification)",

--- a/cellfinder/napari/detect/detect_containers.py
+++ b/cellfinder/napari/detect/detect_containers.py
@@ -15,7 +15,7 @@ class DataInputs(InputContainer):
     """Container for image-related ("Data") inputs."""
 
     signal_array: numpy.ndarray = None
-    background_array: numpy.ndarray = None
+    background_array: Optional[numpy.ndarray] = None
     voxel_size_z: float = 5
     voxel_size_y: float = 2
     voxel_size_x: float = 2

--- a/cellfinder/napari/detect/detect_containers.py
+++ b/cellfinder/napari/detect/detect_containers.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import Enum, auto
 from pathlib import Path
 from typing import List, Optional
 
@@ -123,38 +123,53 @@ class DetectionInputs(InputContainer):
 
 
 class ModelSource(Enum):
-    PRETRAINED = "Pretrained default"
-    CUSTOM = "Custom model"
-    SKIP = "Skip classification"
+    PRETRAINED = auto()
+    CUSTOM = auto()
+    SKIP = auto()
+
+    @classmethod
+    def from_options(
+        cls, skip_classification: bool, use_pre_trained_weights: bool
+    ) -> "ModelSource":
+        if skip_classification:
+            return cls.SKIP
+        return cls.PRETRAINED if use_pre_trained_weights else cls.CUSTOM
 
 
 @dataclass
 class ClassificationInputs(InputContainer):
     """Container for classification inputs."""
 
-    model_source: ModelSource = ModelSource.PRETRAINED
+    skip_classification: bool = False
+    use_pre_trained_weights: bool = True
     trained_model: Optional[Path] = Path.home()
     classification_batch_size: int = 64
     normalize_channels: bool = False
     normalization_n_sampling_planes: int = 50
 
     @property
-    def skip_classification(self) -> bool:
-        return self.model_source is ModelSource.SKIP
+    def model_source(self) -> ModelSource:
+        return ModelSource.from_options(
+            self.skip_classification, self.use_pre_trained_weights
+        )
 
     def as_core_arguments(self) -> dict:
         args = super().as_core_arguments()
-        args["skip_classification"] = self.skip_classification
+        del args["use_pre_trained_weights"]
         if self.model_source is not ModelSource.CUSTOM:
             args["trained_model"] = None
-        del args["model_source"]
         return args
 
     @classmethod
     def widget_representation(cls) -> dict:
         return dict(
             classification_options=html_label_widget("Classification:"),
-            model_source=dict(value=cls.defaults()["model_source"]),
+            skip_classification=dict(
+                value=cls.defaults()["skip_classification"]
+            ),
+            use_pre_trained_weights=dict(
+                value=cls.defaults()["use_pre_trained_weights"]
+            ),
             trained_model=dict(value=cls.defaults()["trained_model"]),
             classification_batch_size=dict(
                 value=cls.defaults()["classification_batch_size"],

--- a/tests/core/test_unit/test_main.py
+++ b/tests/core/test_unit/test_main.py
@@ -79,3 +79,36 @@ def test_optional_background_allows_detection(
     )
 
     mock_detect.assert_called_once()
+
+
+@patch("cellfinder.core.detect.detect.main", return_value=[])
+@patch("cellfinder.core.tools.prep.prep_model_weights")
+def test_missing_background_selects_single_channel_model(
+    mock_prep_weights, mock_detect, signal_array
+):
+    mock_prep_weights.return_value = "/some/weights.keras"
+
+    main(
+        signal_array=signal_array,
+        background_array=None,
+        voxel_sizes=(5, 2, 2),
+    )
+
+    assert mock_prep_weights.call_args.args[2] == "resnet50_1ch"
+
+
+@patch("cellfinder.core.detect.detect.main", return_value=[])
+@patch("cellfinder.core.tools.prep.prep_model_weights")
+def test_explicit_model_is_kept_without_background(
+    mock_prep_weights, mock_detect, signal_array
+):
+    mock_prep_weights.return_value = "/some/weights.h5"
+
+    main(
+        signal_array=signal_array,
+        background_array=None,
+        voxel_sizes=(5, 2, 2),
+        model="resnet50_all",
+    )
+
+    assert mock_prep_weights.call_args.args[2] == "resnet50_all"

--- a/tests/napari/test_curation.py
+++ b/tests/napari/test_curation.py
@@ -119,6 +119,42 @@ def test_cell_marking(curation_widget, tmp_path):
         assert "bg_std" in item
 
 
+def test_save_training_data_without_background(curation_widget, tmp_path):
+    """
+    Saving without a background writes single-channel cubes and a YAML
+    that marks the background channel as absent.
+    """
+    widget = curation_widget
+    widget.add_training_data()
+    viewer = widget.viewer
+
+    points = Points(
+        np.array([[16, 17, 18], [13, 14, 15]]), name="selection_points"
+    )
+    viewer.add_layer(points)
+
+    points.selected_data = [0]
+    widget.mark_as_cell()
+    points.selected_data = [1]
+    widget.mark_as_non_cell()
+
+    layer_data = sample_data.load_sample()
+    widget.signal_layer = Image(layer_data[0][0], **layer_data[0][1])
+    widget.background_layer = None
+
+    widget.output_directory = tmp_path
+    widget.save_training_data(prompt_for_directory=False, block=True)
+
+    assert (tmp_path / "training.yaml").exists()
+    # Only the signal channel is saved for both cells and non_cells.
+    assert len(list((tmp_path / "non_cells").glob("*.tif"))) == 1
+    assert len(list((tmp_path / "cells").glob("*.tif"))) == 1
+
+    with open(tmp_path / "training.yaml") as yaml_file:
+        contents = yaml.safe_load(yaml_file)
+    assert all(section["bg_channel"] == -1 for section in contents["data"])
+
+
 @pytest.fixture
 def valid_curation_widget(make_napari_viewer) -> CurationWidget:
     """
@@ -195,9 +231,42 @@ def test_check_image_data_missing_signal(valid_curation_widget):
         valid_curation_widget.signal_layer = None
         valid_curation_widget.check_image_data_for_extraction()
         show_info.assert_called_once_with(
-            "Please ensure both signal and background images are loaded "
-            "into napari, and selected in the sidebar. "
+            "Please ensure a signal image is loaded into napari, and "
+            "selected in the sidebar. "
         )
+
+
+def test_check_image_data_without_background(valid_curation_widget):
+    """
+    A signal image without a background is extractable.
+    """
+    valid_curation_widget.background_layer = None
+    assert valid_curation_widget.check_image_data_for_extraction()
+
+
+def test_deselect_background_resets_layer(valid_curation_widget):
+    """
+    Clearing the background selection drops the stale layer, so a
+    single-channel run stays reachable from the sidebar.
+    """
+    widget = valid_curation_widget
+    assert widget.background_layer is not None
+    widget.background_image_choice.setCurrentText("")
+    widget.set_background_image()
+    assert widget.background_layer is None
+
+
+def test_deselect_signal_resets_layer(valid_curation_widget):
+    """
+    Clearing the signal selection drops the stale layer.
+    """
+    widget = valid_curation_widget
+    widget.signal_image_choice.setCurrentText("Signal")
+    widget.set_signal_image()
+    assert widget.signal_layer is not None
+    widget.signal_image_choice.setCurrentText("")
+    widget.set_signal_image()
+    assert widget.signal_layer is None
 
 
 def test_valid_widget_has_extractable_data(valid_curation_widget):

--- a/tests/napari/test_curation.py
+++ b/tests/napari/test_curation.py
@@ -7,6 +7,11 @@ import pytest
 import yaml
 from napari.layers import Image, Points
 
+from cellfinder.core.train.train_yaml import (
+    get_tiff_files,
+    make_tiff_lists,
+    parse_yaml,
+)
 from cellfinder.napari import sample_data
 from cellfinder.napari.curation import CurationWidget
 from cellfinder.napari.sample_data import load_sample
@@ -153,6 +158,11 @@ def test_save_training_data_without_background(curation_widget, tmp_path):
     with open(tmp_path / "training.yaml") as yaml_file:
         contents = yaml.safe_load(yaml_file)
     assert all(section["bg_channel"] == -1 for section in contents["data"])
+
+    # The training data is consumed by core training as single-channel.
+    tiff_files = get_tiff_files(parse_yaml([tmp_path / "training.yaml"]))
+    filenames, _ = make_tiff_lists(tiff_files)
+    assert all(len(img_files) == 1 for img_files, _ in filenames)
 
 
 @pytest.fixture

--- a/tests/napari/test_detection.py
+++ b/tests/napari/test_detection.py
@@ -177,6 +177,21 @@ def test_model_source_from_options(skip, use_pre_trained, expected):
     assert ModelSource.from_options(skip, use_pre_trained) is expected
 
 
+def test_trained_model_only_visible_for_a_custom_model(get_detect_widget):
+    """The model file field is only shown when a custom model is chosen."""
+    widget = get_detect_widget
+
+    widget.skip_classification.value = False
+    widget.use_pre_trained_weights.value = True
+    assert widget.trained_model._explicitly_hidden
+
+    widget.use_pre_trained_weights.value = False
+    assert not widget.trained_model._explicitly_hidden
+
+    widget.skip_classification.value = True
+    assert widget.trained_model._explicitly_hidden
+
+
 def test_reset_defaults(get_detect_widget):
     """Smoke test that restore defaults doesn't error."""
     get_detect_widget.reset_button.clicked()

--- a/tests/napari/test_detection.py
+++ b/tests/napari/test_detection.py
@@ -95,13 +95,12 @@ def test_run_detect_without_inputs():
         assert show_info.called
 
 
-def test_run_detect_without_background_needs_single_channel_model(
+def test_run_detect_without_background_uses_pretrained_weights(
     get_detect_widget,
 ):
     """
     Classifying without a background and with the default pretrained
-    (two-channel) weights is rejected with a helpful message, and the
-    worker never starts.
+    weights is allowed; core selects the single-channel model.
     """
     widget = get_detect_widget
     with (
@@ -111,6 +110,28 @@ def test_run_detect_without_background_needs_single_channel_model(
         widget.background_image_opt.background_image.value = None
         widget.skip_classification.value = False
         widget.use_pre_trained_weights.value = True
+        widget.call_button.clicked()
+
+        assert not show_info.called
+        assert worker.called
+
+
+def test_run_detect_without_background_needs_single_channel_model(
+    get_detect_widget,
+):
+    """
+    Classifying without a background, without pretrained weights, and
+    without a chosen single-channel model is rejected with a helpful
+    message, and the worker never starts.
+    """
+    widget = get_detect_widget
+    with (
+        patch("cellfinder.napari.detect.detect.show_info") as show_info,
+        patch("cellfinder.napari.detect.detect.Worker") as worker,
+    ):
+        widget.background_image_opt.background_image.value = None
+        widget.skip_classification.value = False
+        widget.use_pre_trained_weights.value = False
         widget.call_button.clicked()
 
         show_info.assert_called_once()

--- a/tests/napari/test_detection.py
+++ b/tests/napari/test_detection.py
@@ -81,7 +81,7 @@ def test_run_detect(get_detect_widget, analyse_local):
     """
     with patch("cellfinder.napari.detect.detect.Worker") as worker:
         get_detect_widget.analyse_local.value = analyse_local
-        get_detect_widget.model_source.value = ModelSource.SKIP
+        get_detect_widget.skip_classification.value = True
         get_detect_widget.call_button.clicked()
         assert worker.called
 
@@ -109,7 +109,8 @@ def test_run_detect_without_background_uses_pretrained_weights(
         patch("cellfinder.napari.detect.detect.Worker") as worker,
     ):
         widget.background_image_opt.background_image.value = None
-        widget.model_source.value = ModelSource.PRETRAINED
+        widget.skip_classification.value = False
+        widget.use_pre_trained_weights.value = True
         widget.call_button.clicked()
 
         assert not show_info.called
@@ -129,7 +130,8 @@ def test_run_detect_custom_model_without_file_is_rejected(
         patch("cellfinder.napari.detect.detect.Worker") as worker,
     ):
         widget.background_image_opt.background_image.value = None
-        widget.model_source.value = ModelSource.CUSTOM
+        widget.skip_classification.value = False
+        widget.use_pre_trained_weights.value = False
         widget.call_button.clicked()
 
         show_info.assert_called_once()
@@ -152,12 +154,27 @@ def test_run_detect_without_background_custom_model_proceeds(
         patch("cellfinder.napari.detect.detect.Worker") as worker,
     ):
         widget.background_image_opt.background_image.value = None
-        widget.model_source.value = ModelSource.CUSTOM
+        widget.skip_classification.value = False
+        widget.use_pre_trained_weights.value = False
         widget.trained_model.value = model_file
         widget.call_button.clicked()
 
         assert not show_info.called
         assert worker.called
+
+
+@pytest.mark.parametrize(
+    argnames=("skip", "use_pre_trained", "expected"),
+    argvalues=[
+        (False, True, ModelSource.PRETRAINED),
+        (False, False, ModelSource.CUSTOM),
+        (True, False, ModelSource.SKIP),
+        (True, True, ModelSource.SKIP),
+    ],
+)
+def test_model_source_from_options(skip, use_pre_trained, expected):
+    """Skipping classification wins over the pre-trained weights choice."""
+    assert ModelSource.from_options(skip, use_pre_trained) is expected
 
 
 def test_reset_defaults(get_detect_widget):

--- a/tests/napari/test_detection.py
+++ b/tests/napari/test_detection.py
@@ -53,6 +53,7 @@ def test_run_detect(get_detect_widget, analyse_local):
     """
     with patch("cellfinder.napari.detect.detect.Worker") as worker:
         get_detect_widget.analyse_local.value = analyse_local
+        get_detect_widget.skip_classification.value = True
         get_detect_widget.call_button.clicked()
         assert worker.called
 

--- a/tests/napari/test_detection.py
+++ b/tests/napari/test_detection.py
@@ -9,6 +9,7 @@ from cellfinder.napari.detect.detect_containers import (
     DataInputs,
     DetectionInputs,
     MiscInputs,
+    ModelSource,
 )
 from cellfinder.napari.detect.thread_worker import Worker
 from cellfinder.napari.sample_data import load_sample
@@ -80,7 +81,7 @@ def test_run_detect(get_detect_widget, analyse_local):
     """
     with patch("cellfinder.napari.detect.detect.Worker") as worker:
         get_detect_widget.analyse_local.value = analyse_local
-        get_detect_widget.skip_classification.value = True
+        get_detect_widget.model_source.value = ModelSource.SKIP
         get_detect_widget.call_button.clicked()
         assert worker.called
 
@@ -108,21 +109,19 @@ def test_run_detect_without_background_uses_pretrained_weights(
         patch("cellfinder.napari.detect.detect.Worker") as worker,
     ):
         widget.background_image_opt.background_image.value = None
-        widget.skip_classification.value = False
-        widget.use_pre_trained_weights.value = True
+        widget.model_source.value = ModelSource.PRETRAINED
         widget.call_button.clicked()
 
         assert not show_info.called
         assert worker.called
 
 
-def test_run_detect_without_background_needs_single_channel_model(
+def test_run_detect_custom_model_without_file_is_rejected(
     get_detect_widget,
 ):
     """
-    Classifying without a background, without pretrained weights, and
-    without a chosen single-channel model is rejected with a helpful
-    message, and the worker never starts.
+    Choosing a custom model without pointing at a model file is rejected
+    with a helpful message, and the worker never starts.
     """
     widget = get_detect_widget
     with (
@@ -130,13 +129,35 @@ def test_run_detect_without_background_needs_single_channel_model(
         patch("cellfinder.napari.detect.detect.Worker") as worker,
     ):
         widget.background_image_opt.background_image.value = None
-        widget.skip_classification.value = False
-        widget.use_pre_trained_weights.value = False
+        widget.model_source.value = ModelSource.CUSTOM
         widget.call_button.clicked()
 
         show_info.assert_called_once()
-        assert "single-channel model" in show_info.call_args.args[0]
+        assert "trained model file" in show_info.call_args.args[0]
         assert not worker.called
+
+
+def test_run_detect_without_background_custom_model_proceeds(
+    get_detect_widget, tmp_path
+):
+    """
+    A custom model without a background is allowed to proceed; the core
+    validates the channel count downstream.
+    """
+    widget = get_detect_widget
+    model_file = tmp_path / "model.pt"
+    model_file.write_bytes(b"")
+    with (
+        patch("cellfinder.napari.detect.detect.show_info") as show_info,
+        patch("cellfinder.napari.detect.detect.Worker") as worker,
+    ):
+        widget.background_image_opt.background_image.value = None
+        widget.model_source.value = ModelSource.CUSTOM
+        widget.trained_model.value = model_file
+        widget.call_button.clicked()
+
+        assert not show_info.called
+        assert worker.called
 
 
 def test_reset_defaults(get_detect_widget):

--- a/tests/napari/test_detection.py
+++ b/tests/napari/test_detection.py
@@ -43,6 +43,33 @@ def test_detect_worker():
     worker.work()
 
 
+def test_data_inputs_without_background():
+    """
+    A missing background array is passed through to core as None.
+    """
+    signal = load_sample()[0][0]
+    core_arguments = DataInputs(
+        signal_array=signal, background_array=None
+    ).as_core_arguments()
+    assert core_arguments["background_array"] is None
+    assert core_arguments["signal_array"] is signal
+
+
+def test_detect_worker_without_background():
+    """
+    Smoke test to check that the detection worker runs single-channel.
+    """
+    signal = load_sample()[0][0]
+
+    worker = Worker(
+        DataInputs(signal_array=signal, background_array=None),
+        DetectionInputs(),
+        ClassificationInputs(trained_model=None),
+        MiscInputs(start_plane=0, end_plane=1),
+    )
+    worker.work()
+
+
 @pytest.mark.parametrize(
     argnames="analyse_local",
     argvalues=[True, False],  # increase test coverage by covering both cases
@@ -66,6 +93,29 @@ def test_run_detect_without_inputs():
         )  # won't have image layers, so should notice and show info
         widget.call_button.clicked()
         assert show_info.called
+
+
+def test_run_detect_without_background_needs_single_channel_model(
+    get_detect_widget,
+):
+    """
+    Classifying without a background and with the default pretrained
+    (two-channel) weights is rejected with a helpful message, and the
+    worker never starts.
+    """
+    widget = get_detect_widget
+    with (
+        patch("cellfinder.napari.detect.detect.show_info") as show_info,
+        patch("cellfinder.napari.detect.detect.Worker") as worker,
+    ):
+        widget.background_image_opt.background_image.value = None
+        widget.skip_classification.value = False
+        widget.use_pre_trained_weights.value = True
+        widget.call_button.clicked()
+
+        show_info.assert_called_once()
+        assert "single-channel model" in show_info.call_args.args[0]
+        assert not worker.called
 
 
 def test_reset_defaults(get_detect_widget):

--- a/tests/napari/test_worker_signals.py
+++ b/tests/napari/test_worker_signals.py
@@ -5,6 +5,7 @@ from cellfinder.napari.detect.detect_containers import (
     DataInputs,
     DetectionInputs,
     MiscInputs,
+    ModelSource,
 )
 from cellfinder.napari.detect.thread_worker import Worker
 from cellfinder.napari.sample_data import load_sample
@@ -28,7 +29,12 @@ def run_worker_test(
         DataInputs(signal_array=signal, background_array=background),
         DetectionInputs(skip_detection=skip_detection),
         ClassificationInputs(
-            skip_classification=skip_classification, trained_model=None
+            model_source=(
+                ModelSource.SKIP
+                if skip_classification
+                else ModelSource.PRETRAINED
+            ),
+            trained_model=None,
         ),
         MiscInputs(start_plane=0, end_plane=-1),
     )

--- a/tests/napari/test_worker_signals.py
+++ b/tests/napari/test_worker_signals.py
@@ -5,7 +5,6 @@ from cellfinder.napari.detect.detect_containers import (
     DataInputs,
     DetectionInputs,
     MiscInputs,
-    ModelSource,
 )
 from cellfinder.napari.detect.thread_worker import Worker
 from cellfinder.napari.sample_data import load_sample
@@ -29,11 +28,7 @@ def run_worker_test(
         DataInputs(signal_array=signal, background_array=background),
         DetectionInputs(skip_detection=skip_detection),
         ClassificationInputs(
-            model_source=(
-                ModelSource.SKIP
-                if skip_classification
-                else ModelSource.PRETRAINED
-            ),
+            skip_classification=skip_classification,
             trained_model=None,
         ),
         MiscInputs(start_plane=0, end_plane=-1),


### PR DESCRIPTION
Follow-up to the core single-channel support (#619), extending it through the napari UI so users can run detection, curation, and training with only a signal channel. Also closes #636 by auto-selecting the single-channel model in the Python API.

### What changed
- **Detection** (`detect.py`): the background image is now optional. A missing background is passed to core as `None`. Added a guard: running without a background requires a single-channel model, so the widget prompts the user to enable "Skip classification" or uncheck "Use pre-trained weights" and pick a single-channel model.
- **Curation** (`curation.py`): background layer is optional throughout. When absent, only the signal channel is written, and the training YAML marks `bg_channel = -1` (which core training already reads as signal-only). Signal/background selections reset cleanly to `None` when deselected.
- **Core classify** (`classify.py`): skips background normalization when there is no background array.
- **Core model selection** (`main.py`): when `background_array` is `None` and the default multi-channel model is still selected, the API switches to `resnet50_1ch`, avoiding a dimension mismatch (#636). An explicitly chosen model is left untouched.
- **Containers**: `DataInputs.background_array` is now `Optional`.

### Tests
- Save single-channel training data produces single-channel cubes and a `bg_channel: -1` YAML, verified consumable by core training.
- `check_image_data_for_extraction` accepts signal-only; missing-signal message updated.
- Deselecting the background resets the layer.
- `DataInputs(background_array=None)` passthrough and single-channel detection worker smoke test.
- Missing background auto-selects `resnet50_1ch`; an explicit `resnet50_all` is preserved.
