### PR TITLE
Use single underscore for internal CurationWidget methods

### DIFF
--- a/cellfinder/napari/curation.py
+++ b/cellfinder/napari/curation.py
@@ -489,19 +489,19 @@ class CurationWidget(QWidget):
                     if not choice:
                         return
             if self.output_directory is not None:
-                self.__prep_directories_for_save()
-                self.__extract_cubes(block=block)
+                self._prep_directories_for_save()
+                self._extract_cubes(block=block)
                 if block:
-                    self.__finish_save()
+                    self._finish_save()
 
-    def __prep_directories_for_save(self):
+    def _prep_directories_for_save(self):
         self.yaml_filename = self.output_directory / "training.yaml"
         self.cell_cube_dir = self.output_directory / "cells"
         self.no_cell_cube_dir = self.output_directory / "non_cells"
 
-        self.__delete_existing_saved_training_data()
+        self._delete_existing_saved_training_data()
 
-    def __delete_existing_saved_training_data(self):
+    def _delete_existing_saved_training_data(self):
         self.yaml_filename.unlink(missing_ok=True)
         for directory in (
             self.cell_cube_dir,
@@ -512,7 +512,7 @@ class CurationWidget(QWidget):
             else:
                 directory.mkdir(exist_ok=True, parents=True)
 
-    def __extract_cubes(self, *, block=False):
+    def _extract_cubes(self, *, block=False):
         """
         Parameters
         ----------
@@ -534,7 +534,7 @@ class CurationWidget(QWidget):
             @thread_worker(
                 connect={
                     "yielded": self.update_progress,
-                    "returned": lambda _: self.__finish_save(),
+                    "returned": lambda _: self._finish_save(),
                 }
             )
             def extract_cubes():
@@ -542,8 +542,8 @@ class CurationWidget(QWidget):
 
             extract_cubes()
 
-    def __finish_save(self):
-        self.__save_yaml_file()
+    def _finish_save(self):
+        self._save_yaml_file()
         show_info("Done")
         self.update_status_label("Ready")
 
@@ -681,7 +681,7 @@ class CurationWidget(QWidget):
         )
         return signal_stat, bg_stat
 
-    def __save_yaml_file(self):
+    def _save_yaml_file(self):
         signal_stat, bg_stat = self._calculate_channel_stats()
         bg_channel = 1 if self.has_background else NO_BACKGROUND_CHANNEL
 


### PR DESCRIPTION
Closes #624

## Description

Renames five internal helpers in `cellfinder/napari/curation.py` from `__name` to `_name`. A leading `__` triggers name mangling, which exists to avoid clashes with subclasses rather than to mark a method as internal; the convention for internal is a single underscore, as used everywhere else in the repo and by existing helpers in this same file.

| Current | Renamed to |
| --- | --- |
| `__prep_directories_for_save` | `_prep_directories_for_save` |
| `__delete_existing_saved_training_data` | `_delete_existing_saved_training_data` |
| `__extract_cubes` | `_extract_cubes` |
| `__finish_save` | `_finish_save` |
| `__save_yaml_file` | `_save_yaml_file` |

Raised by @alessandrofelder in review of #621.

## What this does not change

Genuine Python protocol methods (`__init__`, `__call__`, `__len__`, etc.) elsewhere in the codebase are untouched.

## References

All call sites are internal to `CurationWidget`, so there is no public API change and no behaviour change. Pure rename: 11 lines, all in `cellfinder/napari/curation.py`.
