### PR TITLE
Validate training paths instead of overloading Path.home()

### DIFF
--- a/cellfinder/napari/detect/detect.py
+++ b/cellfinder/napari/detect/detect.py
@@ -141,14 +141,13 @@ def restore_options_defaults(widget: FunctionGui) -> None:
     Restore default widget values.
     """
     defaults = {
-        **DataInputs.defaults(),
-        **DetectionInputs.defaults(),
-        **ClassificationInputs.defaults(),
-        **MiscInputs.defaults(),
+        **DataInputs.widget_defaults(),
+        **DetectionInputs.widget_defaults(),
+        **ClassificationInputs.widget_defaults(),
+        **MiscInputs.widget_defaults(),
     }
     for name, value in defaults.items():
-        if value is not None:  # ignore fields with no default
-            getattr(widget, name).value = value
+        getattr(widget, name).value = value
 
 
 def get_results_callback(

--- a/cellfinder/napari/detect/detect_containers.py
+++ b/cellfinder/napari/detect/detect_containers.py
@@ -142,7 +142,7 @@ class ClassificationInputs(InputContainer):
 
     skip_classification: bool = False
     use_pre_trained_weights: bool = True
-    trained_model: Optional[Path] = Path.home()
+    trained_model: Optional[Path] = None
     classification_batch_size: int = 64
     normalize_channels: bool = False
     normalization_n_sampling_planes: int = 50

--- a/cellfinder/napari/input_container.py
+++ b/cellfinder/napari/input_container.py
@@ -35,6 +35,20 @@ class InputContainer:
         # to avoid code repetition.
         return asdict_no_copy(cls())
 
+    @classmethod
+    def widget_defaults(cls) -> dict:
+        """Returns default values of the fields shown as widgets.
+
+        Fields the class does not represent as a widget, such as layer
+        selections, have no default to restore.
+        """
+        defaults = cls.defaults()
+        return {
+            name: defaults[name]
+            for name in cls.widget_representation()
+            if name in defaults
+        }
+
     @abstractmethod
     def as_core_arguments(self) -> dict:
         """Determines how dataclass fields are passed to cellfinder-core.

--- a/cellfinder/napari/train/train.py
+++ b/cellfinder/napari/train/train.py
@@ -49,8 +49,8 @@ def training_widget() -> FunctionGui:
     def widget(
         training_label: dict,
         data_options: dict,
-        yaml_files: Path,
-        output_directory: Path,
+        yaml_files: Optional[Path],
+        output_directory: Optional[Path],
         network_options: dict,
         trained_model: Optional[Path],
         model_weights: Optional[Path],
@@ -76,9 +76,9 @@ def training_widget() -> FunctionGui:
         """
         Parameters
         ----------
-        yaml_files : Path
+        yaml_files : Optional[Path]
             YAML files containing paths to training data
-        output_directory : Path
+        output_directory : Optional[Path]
             Directory to save the output trained model
         trained_model : Optional[Path]
             Existing pre-trained model
@@ -129,10 +129,12 @@ def training_widget() -> FunctionGui:
         reset_button : PushButton
             Reset parameters to default
         """
-        trained_model = None if trained_model == Path.home() else trained_model
-        model_weights = None if model_weights == Path.home() else model_weights
-
         training_data_inputs = TrainingDataInputs(yaml_files, output_directory)
+
+        validation_error = training_data_inputs.validation_error()
+        if validation_error is not None:
+            show_info(validation_error)
+            return
 
         optional_network_inputs = OptionalNetworkInputs(
             trained_model,
@@ -158,32 +160,27 @@ def training_widget() -> FunctionGui:
 
         misc_training_inputs = MiscTrainingInputs(number_of_free_cpus)
 
-        if yaml_files[0] == Path.home():  # type: ignore
-            show_info("Please select a YAML file for training")
-        else:
-            show_info("Starting training process...")
-            worker = run_training(
-                training_data_inputs,
-                optional_network_inputs,
-                optional_training_inputs,
-                misc_training_inputs,
-            )
-            worker.start()
+        show_info("Starting training process...")
+        worker = run_training(
+            training_data_inputs,
+            optional_network_inputs,
+            optional_training_inputs,
+            misc_training_inputs,
+        )
+        worker.start()
 
     widget.native.layout().insertWidget(0, cellfinder_header())
 
     @widget.reset_button.changed.connect
     def restore_defaults():
         defaults = {
-            **TrainingDataInputs.defaults(),
-            **OptionalNetworkInputs.defaults(),
-            **OptionalTrainingInputs.defaults(),
-            **MiscTrainingInputs.defaults(),
+            **TrainingDataInputs.widget_defaults(),
+            **OptionalNetworkInputs.widget_defaults(),
+            **OptionalTrainingInputs.widget_defaults(),
+            **MiscTrainingInputs.widget_defaults(),
         }
         for name, value in defaults.items():
-            # ignore fields with no default
-            if value is not None:
-                getattr(widget, name).value = value
+            getattr(widget, name).value = value
 
     scroll = QScrollArea()
     scroll.setWidget(widget._widget._qwidget)

--- a/cellfinder/napari/train/train_containers.py
+++ b/cellfinder/napari/train/train_containers.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
@@ -14,14 +15,32 @@ from cellfinder.napari.utils import html_label_widget
 class TrainingDataInputs(InputContainer):
     """Container for Training Data input widgets"""
 
-    yaml_files: Path = Path.home()
-    output_directory: Path = Path.home()
+    yaml_files: Optional[Sequence[Path]] = None
+    output_directory: Optional[Path] = None
 
     def as_core_arguments(self) -> dict:
         arguments = super().as_core_arguments()
         arguments["output_dir"] = arguments.pop("output_directory")
         arguments["yaml_file"] = arguments.pop("yaml_files")
         return arguments
+
+    def validation_error(self) -> Optional[str]:
+        """Returns why these inputs can't be trained on, if they can't."""
+        if not self.yaml_files:
+            return "Please select a YAML file for training"
+
+        for yaml_file in map(Path, self.yaml_files):
+            if yaml_file.suffix != ".yaml":
+                return f"Not a YAML file: {yaml_file.name}"
+            if not yaml_file.is_file():
+                return f"YAML file does not exist: {yaml_file}"
+
+        if self.output_directory is None:
+            return "Please select an output directory"
+        if not Path(self.output_directory).is_dir():
+            return f"Output directory does not exist: {self.output_directory}"
+
+        return None
 
     @classmethod
     def widget_representation(cls) -> dict:
@@ -43,8 +62,8 @@ class TrainingDataInputs(InputContainer):
 class OptionalNetworkInputs(InputContainer):
     """Container for Optional Network input widgets"""
 
-    trained_model: Optional[Path] = Path.home()
-    model_weights: Optional[Path] = Path.home()
+    trained_model: Optional[Path] = None
+    model_weights: Optional[Path] = None
     model_depth: str = list(models.keys())[2]
     pretrained_model: str = str(list(model_filenames.keys())[0])
 

--- a/tests/napari/test_training.py
+++ b/tests/napari/test_training.py
@@ -12,6 +12,12 @@ from cellfinder.napari.train.train_containers import (
 )
 
 
+def make_yaml_file(directory: Path, index: int) -> Path:
+    yaml_file = directory / f"file_{index}.yaml"
+    yaml_file.write_text("[]\n")
+    return yaml_file
+
+
 @pytest.fixture
 def get_training_widget(make_napari_viewer):
     viewer = make_napari_viewer()
@@ -38,8 +44,10 @@ def test_reset_to_defaults(get_training_widget):
     get_training_widget.reset_button.clicked()
 
     # check values have been reset
-    assert len(get_training_widget.yaml_files.value) == 1
-    assert get_training_widget.yaml_files.value[0] == Path.home()
+    assert get_training_widget.yaml_files.value is None
+    assert get_training_widget.output_directory.value is None
+    assert get_training_widget.trained_model.value is None
+    assert get_training_widget.model_weights.value is None
     assert not get_training_widget.continue_training.value
     assert get_training_widget.epochs.value == 100
     assert get_training_widget.test_fraction.value == 0.10
@@ -57,18 +65,61 @@ def test_run_with_no_yaml_files(get_training_widget):
         )
 
 
-def test_run_with_virtual_yaml_files(get_training_widget):
+def test_run_with_no_output_directory(get_training_widget, tmp_path):
+    """
+    Checks the user is told to pick an output directory rather than the
+    training silently writing to whatever the default happens to be.
+    """
+    get_training_widget.yaml_files.value = (make_yaml_file(tmp_path, 1),)
+
+    with (
+        patch("cellfinder.napari.train.train.show_info") as show_info,
+        patch("cellfinder.napari.train.train.run_training") as run_training,
+    ):
+        get_training_widget.call_button.clicked()
+
+    show_info.assert_called_once_with("Please select an output directory")
+    run_training.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "filename, expected_message",
+    [
+        ("not_yaml.txt", "Not a YAML file: not_yaml.txt"),
+        ("missing.yaml", "YAML file does not exist: {path}"),
+    ],
+)
+def test_run_with_invalid_yaml_files(
+    get_training_widget, tmp_path, filename, expected_message
+):
+    """
+    Checks YAML files are rejected if they are the wrong format or absent.
+    """
+    yaml_file = tmp_path / filename
+    get_training_widget.yaml_files.value = (yaml_file,)
+    get_training_widget.output_directory.value = tmp_path
+
+    with (
+        patch("cellfinder.napari.train.train.show_info") as show_info,
+        patch("cellfinder.napari.train.train.run_training") as run_training,
+    ):
+        get_training_widget.call_button.clicked()
+
+    show_info.assert_called_once_with(expected_message.format(path=yaml_file))
+    run_training.assert_not_called()
+
+
+def test_run_with_yaml_files(get_training_widget, tmp_path):
     """
     Checks that training is run with expected set of parameters.
     """
+    output_directory = tmp_path / "output"
+    output_directory.mkdir()
+    yaml_files = tuple(make_yaml_file(tmp_path, index) for index in (1, 2))
+
     with patch("cellfinder.napari.train.train.run_training") as run_training:
-        # make default input valid - need yaml files (they don't technically
-        # have to exist)
-        virtual_yaml_files = (
-            Path.home() / "file_1.yaml",
-            Path.home() / "file_2.yaml",
-        )
-        get_training_widget.yaml_files.value = virtual_yaml_files
+        get_training_widget.yaml_files.value = yaml_files
+        get_training_widget.output_directory.value = output_directory
         get_training_widget.call_button.clicked()
 
         # create expected arguments for run
@@ -80,11 +131,8 @@ def test_run_with_virtual_yaml_files(get_training_widget):
         # so to do equality comparison, we need to set default to list also
         expected_optional_training_args.lr_schedule = []
 
-        # we expect the widget to make some changes to the defaults
-        # displayed before calling the training backend
-        expected_training_args.yaml_files = virtual_yaml_files
-        expected_network_args.trained_model = None
-        expected_network_args.model_weights = None
+        expected_training_args.yaml_files = yaml_files
+        expected_training_args.output_directory = output_directory
 
         run_training.assert_called_once_with(
             expected_training_args,

--- a/tests/napari/test_training.py
+++ b/tests/napari/test_training.py
@@ -12,10 +12,16 @@ from cellfinder.napari.train.train_containers import (
 )
 
 
-def make_yaml_file(directory: Path, index: int) -> Path:
-    yaml_file = directory / f"file_{index}.yaml"
-    yaml_file.write_text("[]\n")
-    return yaml_file
+@pytest.fixture
+def make_dummy_yaml(tmp_path):
+    """Returns a factory for empty YAML files in a temporary directory."""
+
+    def _make_dummy_yaml(index: int) -> Path:
+        yaml_file = tmp_path / f"file_{index}.yaml"
+        yaml_file.write_text("[]\n")
+        return yaml_file
+
+    return _make_dummy_yaml
 
 
 @pytest.fixture
@@ -65,12 +71,12 @@ def test_run_with_no_yaml_files(get_training_widget):
         )
 
 
-def test_run_with_no_output_directory(get_training_widget, tmp_path):
+def test_run_with_no_output_directory(get_training_widget, make_dummy_yaml):
     """
     Checks the user is told to pick an output directory rather than the
     training silently writing to whatever the default happens to be.
     """
-    get_training_widget.yaml_files.value = (make_yaml_file(tmp_path, 1),)
+    get_training_widget.yaml_files.value = (make_dummy_yaml(1),)
 
     with (
         patch("cellfinder.napari.train.train.show_info") as show_info,
@@ -109,13 +115,13 @@ def test_run_with_invalid_yaml_files(
     run_training.assert_not_called()
 
 
-def test_run_with_yaml_files(get_training_widget, tmp_path):
+def test_run_with_yaml_files(get_training_widget, tmp_path, make_dummy_yaml):
     """
     Checks that training is run with expected set of parameters.
     """
     output_directory = tmp_path / "output"
     output_directory.mkdir()
-    yaml_files = tuple(make_yaml_file(tmp_path, index) for index in (1, 2))
+    yaml_files = tuple(make_dummy_yaml(index) for index in (1, 2))
 
     with patch("cellfinder.napari.train.train.run_training") as run_training:
         get_training_widget.yaml_files.value = yaml_files


### PR DESCRIPTION
Closes #328

## Problem

The napari training widget used `Path.home()` as a sentinel for "nothing selected". Three inputs were compared against it to decide whether the user had actually chosen a model, a weights file, or YAML files:

```python
trained_model = None if trained_model == Path.home() else trained_model
model_weights = None if model_weights == Path.home() else model_weights
...
if yaml_files[0] == Path.home():
    show_info("Please select a YAML file for training")
```

`output_directory` shared the same `Path.home()` default but was never compared against it, so nothing stopped a run from starting with it. Selecting YAML files and clicking Run without touching Output directory dispatched training with `output_directory=PosixPath('/home/<user>')`, writing checkpoints, tensorboard logs and the trained model into the user's home directory.

The sentinel had two smaller consequences: only `yaml_files[0]` was checked, so nothing validated the rest of a multi-file selection, and a model path that genuinely resolved to the home directory would have been silently reinterpreted as "unset".

## Background

#337 asked for the plugin's inputs to be split into structs "each with their validator", after a bad model file in brainglobe/cellfinder-napari#43 only failed once detection had already run. `InputContainer` is those structs, but the validator half was never built, which is why this widget compares against a sentinel path instead.

## Change

**`cellfinder/napari/train/train_containers.py`** — the four training paths default to `None` instead of `Path.home()`, and `TrainingDataInputs` validates its own fields:

```python
def validation_error(self) -> Optional[str]:
    """Returns why these inputs can't be trained on, if they can't."""
    if not self.yaml_files:
        return "Please select a YAML file for training"

    for yaml_file in map(Path, self.yaml_files):
        if yaml_file.suffix != ".yaml":
            return f"Not a YAML file: {yaml_file.name}"
        if not yaml_file.is_file():
            return f"YAML file does not exist: {yaml_file}"

    if self.output_directory is None:
        return "Please select an output directory"
    if not Path(self.output_directory).is_dir():
        return f"Output directory does not exist: {self.output_directory}"

    return None
```

**`cellfinder/napari/train/train.py`** — both sentinel comparisons and the `yaml_files[0]` guard are gone; the widget asks the container and shows the reason on screen, as #337 asked for:

```python
training_data_inputs = TrainingDataInputs(yaml_files, output_directory)

validation_error = training_data_inputs.validation_error()
if validation_error is not None:
    show_info(validation_error)
    return
```

Training's inputs are all `TrainingDataInputs` fields, so validation lives on the container. The detection widget keeps its checks inline for now, because most of them concern napari layers rather than container fields; only its `trained_model` check would move.

`yaml_files` and `output_directory` are also annotated `Optional[Path]` in the `@magicgui` signature: that annotation, not the dataclass field, is what makes a `FileEdit` nullable, and without it `set_value(None)` raises when the reset button fires.

**`cellfinder/napari/detect/detect_containers.py`** — `ClassificationInputs.trained_model` defaulted to `Path.home()` too. It was already cosmetic, since `as_core_arguments` forces `None` unless a custom model is selected, but it is the last sentinel and is now `None`.

**`cellfinder/napari/input_container.py`** — both widgets restored defaults by skipping any field whose default was `None`. That guard stood in for "this field isn't really a widget", protecting the image-layer selections, and it breaks once the path fields legitimately default to `None`. The containers already declare which fields are widgets, so the base class answers the question directly:

```python
@classmethod
def widget_defaults(cls) -> dict:
    """Returns default values of the fields shown as widgets.

    Fields the class does not represent as a widget, such as layer
    selections, have no default to restore.
    """
    defaults = cls.defaults()
    return {
        name: defaults[name]
        for name in cls.widget_representation()
        if name in defaults
    }
```

`restore_defaults` and `restore_options_defaults` now call it and assign unconditionally, so a future non-widget field needs no guard.

After this, `Path.home()` appears once in the codebase, in `DEFAULT_CELLFINDER_DIRECTORY`, which is a genuine home-directory use.

## Behaviour change

A training run that previously started with the default output directory now stops and asks for one. Non-existent YAML files are also rejected at the widget rather than failing later inside `train_yaml`.

## Verification

The bug was reproduced against `main` before the fix by driving the real widget through the napari fixture. With YAML files selected and the output directory untouched, `run_training` was called with

```
TrainingDataInputs(yaml_files=(PosixPath('.../training.yaml'),),
                   output_directory=PosixPath('/home/<user>'))
```

After the change the same sequence shows "Please select an output directory" and `run_training` is not called.
