### PR TITLE
Remove dead fiji coordinate helper functions

### DIFF
--- a/cellfinder/core/tools/tools.py
+++ b/cellfinder/core/tools/tools.py
@@ -240,18 +240,6 @@ def get_number_of_bins_nd(array_size, binning):
     return tuple(bins)
 
 
-def interchange_np_fiji_coordinates(tuple_in):
-    """
-    Swaps the first and second element of a tuple to swap between the numpy
-    convention (vertical is first) and FIJI convention (horizontal is first)
-    :param tuple_in: A 2+ element tuple
-    :return: Same tuple with element 0 and 1 interchanged
-    """
-    tmp_list = list(tuple_in)
-    tmp_list = swap_elements_list(tmp_list, 0, 1)
-    return tuple(tmp_list)
-
-
 def swap_elements_list(list_in, swap_a, swap_b):
     """
     Swap two elements in a list

--- a/cellfinder/core/tools/tools.py
+++ b/cellfinder/core/tools/tools.py
@@ -240,18 +240,6 @@ def get_number_of_bins_nd(array_size, binning):
     return tuple(bins)
 
 
-def swap_elements_list(list_in, swap_a, swap_b):
-    """
-    Swap two elements in a list
-    :param list_in: A list
-    :param swap_a: Index of first element to swap
-    :param swap_b: Index of second element to swap
-    :return: List with swap_a and swap_b exchanged
-    """
-    list_in[swap_a], list_in[swap_b] = list_in[swap_b], list_in[swap_a]
-    return list_in
-
-
 def is_any_list_overlap(list_a, list_b):
     """
     Is there any overlap between two lists

--- a/tests/core/test_unit/test_tools/test_tools_general.py
+++ b/tests/core/test_unit/test_tools/test_tools_general.py
@@ -248,11 +248,6 @@ def test_get_number_of_bins_nd():
         tools.get_number_of_bins_nd([200, 300, 400], 10)
 
 
-def test_swap_elements_list():
-    list_in = [1, 2, 3, 4]
-    assert tools.swap_elements_list(list_in, 1, 2) == [1, 3, 2, 4]
-
-
 def test_is_any_list_overlap():
     assert tools.is_any_list_overlap(a, b)
     assert not tools.is_any_list_overlap(a, [2, "b", (1, 2, 3)])

--- a/tests/core/test_unit/test_tools/test_tools_general.py
+++ b/tests/core/test_unit/test_tools/test_tools_general.py
@@ -248,11 +248,6 @@ def test_get_number_of_bins_nd():
         tools.get_number_of_bins_nd([200, 300, 400], 10)
 
 
-def test_interchange_np_fiji_coordinates():
-    tuple_in = (100, 200, 300)
-    assert tools.interchange_np_fiji_coordinates(tuple_in) == (200, 100, 300)
-
-
 def test_swap_elements_list():
     list_in = [1, 2, 3, 4]
     assert tools.swap_elements_list(list_in, 1, 2) == [1, 3, 2, 4]


### PR DESCRIPTION
`cellfinder.core.tools.tools.interchange_np_fiji_coordinates` does not hav a caller. Only its own unit test.

Verified no usage in this repo, `brainglobe-workflows`, or `cellfinder-napari` (latest HEAD).

Two commits:
1. Remove `interchange_np_fiji_coordinates` and its test
2. Remove `swap_elements_list`, which becomes orphaned by commit 1, and its test